### PR TITLE
fix(help): unrendered html

### DIFF
--- a/src/cheating-daddy-element.js
+++ b/src/cheating-daddy-element.js
@@ -831,11 +831,11 @@ class CheatingDaddyApp extends LitElement {
                 <div class="option-group">
                     <span class="option-label">Audio Input</span>
                     <div class="description">
-                        ${cheddar.isMacOS
-                            ? '<strong>macOS:</strong> Uses SystemAudioDump for system audio capture'
+                        ${cheddar.isMacOS 
+                            ? html`<strong>macOS:</strong> Uses SystemAudioDump for system audio capture`
                             : cheddar.isLinux
-                              ? '<strong>Linux:</strong> Uses microphone input'
-                              : '<strong>Windows:</strong> Uses loopback audio capture'}<br />
+                              ? html`<strong>Linux:</strong> Uses microphone input`
+                              : html`<strong>Windows:</strong> Uses loopback audio capture`}<br />
                         The AI listens to conversations and provides contextual assistance based on what it hears.
                     </div>
                 </div>


### PR DESCRIPTION
Tiny little UI bug with unrendered HTML in the help section

- I tried taking a screenshot but, well, it's undetectable