### PR TITLE
Fix: Ctrl+\ shortcut now correctly toggles window visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ typings/
 
 # Electron-Forge
 out/
+.specstory
+.specstory/

--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,13 @@ function createWindow() {
         });
     });
 
-    const closeShortcut = isMac ? 'Cmd+\\' : 'Ctrl+\\';
-    globalShortcut.register(closeShortcut, () => {
-        mainWindow.close();
+    const toggleVisibilityShortcut = isMac ? 'Cmd+\\' : 'Ctrl+\\';
+    globalShortcut.register(toggleVisibilityShortcut, () => {
+        if (mainWindow.isVisible()) {
+            mainWindow.hide();
+        } else {
+            mainWindow.show();
+        }
     });
 
     const toggleShortcut = isMac ? 'Cmd+M' : 'Ctrl+M';


### PR DESCRIPTION
This pull request resolves an issue where the Ctrl+\ (or Cmd+\ on macOS) keyboard shortcut was only closing the application window instead of toggling its visibility.
Changes made:
Modified the global shortcut registration in src/index.js.
The shortcut now checks if the mainWindow is visible.
If visible, it hides the window.
If hidden, it shows the window.
This ensures that the Ctrl+\ shortcut behaves as an intuitive toggle for the application window, allowing users to quickly show or hide it as needed.