### PR TITLE
linux appimage build and audio fix

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -42,12 +42,18 @@ module.exports = {
             platforms: ['darwin'],
         },
         {
-            name: '@electron-forge/maker-deb',
-            config: {},
-        },
-        {
-            name: '@electron-forge/maker-rpm',
-            config: {},
+            name: '@reforged/maker-appimage',
+            platforms: ['linux'],
+            config: {
+                options: {
+                    name: 'Cheating Daddy',
+                    productName: 'Cheating Daddy',
+                    genericName: 'AI Assistant',
+                    description: 'AI assistant for interviews and learning',
+                    categories: ['Development', 'Education'],
+                    icon: 'src/assets/logo.png'
+                }
+            },
         },
     ],
     plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
                 "@electron-forge/plugin-fuses": "^7.8.1",
                 "@electron/fuses": "^1.8.0",
+                "@reforged/maker-appimage": "^5.0.0",
                 "electron": "30.0.0"
             }
         },
@@ -1243,6 +1244,37 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/@reforged/maker-appimage": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-5.0.0.tgz",
+            "integrity": "sha512-25nli9nt5MVMRladnoJ3uP5W+2KpND5mzA36rc/Duj/R71oGcOj3t9Uoc/dDmaED8afAEeaSYpVE7VPPe9T54A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+                "@reforged/maker-types": "^1.0.0",
+                "@spacingbat3/lss": "^1.0.0",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=19.0.0 || ^18.11.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+            }
+        },
+        "node_modules/@reforged/maker-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@reforged/maker-types/-/maker-types-1.0.1.tgz",
+            "integrity": "sha512-gjLr6O7rS8XzjbqCEo/BxT4mrevWuYKdMzc0uO6dNcWDXinfhJVHT3aEZmtMyn1nx+ZbffzpCFPgGNYZtwGXxQ==",
+            "dev": true,
+            "license": "ISC",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1255,6 +1287,13 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
+        },
+        "node_modules/@spacingbat3/lss": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.2.0.tgz",
+            "integrity": "sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
         "@electron-forge/plugin-fuses": "^7.8.1",
         "@electron/fuses": "^1.8.0",
+        "@reforged/maker-appimage": "^5.0.0",
         "electron": "30.0.0"
     }
 }

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -192,17 +192,44 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
 
             console.log('macOS screen capture started - audio handled by SystemAudioDump');
         } else if (isLinux) {
-            // Linux - use display media for screen capture and getUserMedia for microphone
-            mediaStream = await navigator.mediaDevices.getDisplayMedia({
-                video: {
-                    frameRate: 1,
-                    width: { ideal: 1920 },
-                    height: { ideal: 1080 },
-                },
-                audio: false, // Don't use system audio loopback on Linux
-            });
+            // Linux - use display media for screen capture and try to get system audio
+            try {
+                // First try to get system audio via getDisplayMedia (works on newer browsers)
+                mediaStream = await navigator.mediaDevices.getDisplayMedia({
+                    video: {
+                        frameRate: 1,
+                        width: { ideal: 1920 },
+                        height: { ideal: 1080 },
+                    },
+                    audio: {
+                        sampleRate: SAMPLE_RATE,
+                        channelCount: 1,
+                        echoCancellation: false, // Don't cancel system audio
+                        noiseSuppression: false,
+                        autoGainControl: false,
+                    },
+                });
 
-            // Get microphone input for Linux
+                console.log('Linux system audio capture via getDisplayMedia succeeded');
+                
+                // Setup audio processing for Linux system audio
+                setupLinuxSystemAudioProcessing();
+                
+            } catch (systemAudioError) {
+                console.warn('System audio via getDisplayMedia failed, trying screen-only capture:', systemAudioError);
+                
+                // Fallback to screen-only capture
+                mediaStream = await navigator.mediaDevices.getDisplayMedia({
+                    video: {
+                        frameRate: 1,
+                        width: { ideal: 1920 },
+                        height: { ideal: 1080 },
+                    },
+                    audio: false,
+                });
+            }
+
+            // Additionally get microphone input for Linux
             let micStream = null;
             try {
                 micStream = await navigator.mediaDevices.getUserMedia({
@@ -225,7 +252,7 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
                 // Continue without microphone if permission denied
             }
 
-            console.log('Linux screen capture started');
+            console.log('Linux capture started - system audio:', mediaStream.getAudioTracks().length > 0, 'microphone:', micStream !== null);
         } else {
             // Windows - use display media with loopback for system audio
             mediaStream = await navigator.mediaDevices.getDisplayMedia({
@@ -302,7 +329,37 @@ function setupLinuxMicProcessing(micStream) {
     micProcessor.connect(micAudioContext.destination);
 
     // Store processor reference for cleanup
-    audioProcessor = micProcessor;
+    micAudioProcessor = micProcessor;
+}
+
+function setupLinuxSystemAudioProcessing() {
+    // Setup system audio processing for Linux (from getDisplayMedia)
+    audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
+    const source = audioContext.createMediaStreamSource(mediaStream);
+    audioProcessor = audioContext.createScriptProcessor(BUFFER_SIZE, 1, 1);
+
+    let audioBuffer = [];
+    const samplesPerChunk = SAMPLE_RATE * AUDIO_CHUNK_DURATION;
+
+    audioProcessor.onaudioprocess = async e => {
+        const inputData = e.inputBuffer.getChannelData(0);
+        audioBuffer.push(...inputData);
+
+        // Process audio in chunks
+        while (audioBuffer.length >= samplesPerChunk) {
+            const chunk = audioBuffer.splice(0, samplesPerChunk);
+            const pcmData16 = convertFloat32ToInt16(chunk);
+            const base64Data = arrayBufferToBase64(pcmData16.buffer);
+
+            await ipcRenderer.invoke('send-audio-content', {
+                data: base64Data,
+                mimeType: 'audio/pcm;rate=24000',
+            });
+        }
+    };
+
+    source.connect(audioProcessor);
+    audioProcessor.connect(audioContext.destination);
 }
 
 function setupWindowsLoopbackProcessing() {
@@ -460,6 +517,12 @@ function stopCapture() {
     if (audioProcessor) {
         audioProcessor.disconnect();
         audioProcessor = null;
+    }
+
+    // Clean up microphone audio processor (Linux only)
+    if (micAudioProcessor) {
+        micAudioProcessor.disconnect();
+        micAudioProcessor = null;
     }
 
     if (audioContext) {


### PR DESCRIPTION
It gives a linux appimage build which is distro agnostic and fixes the audio issues on linux (only tested with pipewire but it's the most popular audio framework anyways). The screen is not hidden whatsoever but I don't know how it can be achieved in linux anyways. I mean linux users don't need to cheat anyways smh smh, it can be used for studying with ai with near zero latency etc etc