### PR TITLE
fix for issue #161

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ A real-time AI assistant that provides contextual help during video calls, inter
 
 ## Features
 
-- **Live AI Assistance**: Real-time help powered by Google Gemini 2.0 Flash Live
-- **Screen & Audio Capture**: Analyzes what you see and hear for contextual responses
-- **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation
-- **Transparent Overlay**: Always-on-top window that can be positioned anywhere
-- **Click-through Mode**: Make window transparent to clicks when needed
-- **Cross-platform**: Works on macOS, Windows, and Linux (kinda, dont use, just for testing rn)
+-   **Live AI Assistance**: Real-time help powered by Google Gemini 2.0 Flash Live
+-   **Screen & Audio Capture**: Analyzes what you see and hear for contextual responses
+-   **Multiple Profiles**: Interview, Sales Call, Business Meeting, Presentation, Negotiation
+-   **Transparent Overlay**: Always-on-top window that can be positioned anywhere
+-   **Click-through Mode**: Make window transparent to clicks when needed
+-   **Cross-platform**: Works on macOS, Windows, and Linux (kinda, dont use, just for testing rn)
 
 ## Setup
 
@@ -41,20 +41,28 @@ A real-time AI assistant that provides contextual help during video calls, inter
 
 ## Keyboard Shortcuts
 
-- **Window Movement**: `Ctrl/Cmd + Arrow Keys` - Move window
-- **Click-through**: `Ctrl/Cmd + M` - Toggle mouse events
-- **Close/Back**: `Ctrl/Cmd + \` - Close window or go back
-- **Send Message**: `Enter` - Send text to AI
+-   **Window Movement**: `Ctrl/Cmd + Arrow Keys` - Move window
+-   **Click-through**: `Ctrl/Cmd + M` - Toggle mouse events
+-   **Close/Back**: `Ctrl/Cmd + \` - Close window or go back
+-   **Send Message**: `Enter` - Send text to AI
 
 ## Audio Capture
 
-- **macOS**: [SystemAudioDump](https://github.com/Mohammed-Yasin-Mulla/Sound) for system audio
-- **Windows**: Loopback audio capture
-- **Linux**: Microphone input
+-   **macOS**: [SystemAudioDump](https://github.com/Mohammed-Yasin-Mulla/Sound) for system audio
+-   **Windows**: Loopback audio capture
+-   **Linux**: Microphone input
+
+## Device Selection (Microphone & Speaker)
+
+-   The app now lets you choose which microphone and speaker the application uses from Settings → Customize → Audio & Microphone.
+-   Selections are persisted to the local app configuration and to renderer `localStorage`, so they survive restarts.
+-   The selected microphone is used when the app requests audio capture (`getUserMedia`) so your preferred input will be used for transcription and analysis.
+-   When supported by the platform and Electron version, the selected speaker is applied to audio playback elements via `setSinkId`. If `setSinkId` is not available on your platform, the app will fall back to the system default output.
+-   Note: Device labels may be blank until you grant microphone permission; grant access and re-open Settings to see friendly names.
 
 ## Requirements
 
-- Electron-compatible OS (macOS, Windows, Linux)
-- Gemini API key
-- Screen recording permissions
-- Microphone/audio permissions
+-   Electron-compatible OS (macOS, Windows, Linux)
+-   Gemini API key
+-   Screen recording permissions
+-   Microphone/audio permissions

--- a/src/config.js
+++ b/src/config.js
@@ -5,15 +5,20 @@ const os = require('os');
 // Default configuration
 const DEFAULT_CONFIG = {
     onboarded: false,
-    stealthLevel: "balanced",
-    layout: "normal"
+    stealthLevel: 'balanced',
+    layout: 'normal',
+    // Preferred audio device IDs
+    audioDevices: {
+        microphoneId: '',
+        speakerId: '',
+    },
 };
 
 // Get the config directory path based on OS
 function getConfigDir() {
     const platform = os.platform();
     let configDir;
-    
+
     if (platform === 'win32') {
         // Windows: %APPDATA%\cheating-daddy-config
         configDir = path.join(os.homedir(), 'AppData', 'Roaming', 'cheating-daddy-config');
@@ -24,7 +29,7 @@ function getConfigDir() {
         // Linux and others: ~/.config/cheating-daddy-config
         configDir = path.join(os.homedir(), '.config', 'cheating-daddy-config');
     }
-    
+
     return configDir;
 }
 
@@ -43,7 +48,7 @@ function ensureConfigDir() {
 // Read existing config or return empty object
 function readExistingConfig() {
     const configFilePath = getConfigFilePath();
-    
+
     try {
         if (fs.existsSync(configFilePath)) {
             const configData = fs.readFileSync(configFilePath, 'utf8');
@@ -52,7 +57,7 @@ function readExistingConfig() {
     } catch (error) {
         console.warn('Error reading config file:', error.message);
     }
-    
+
     return {};
 }
 
@@ -60,7 +65,7 @@ function readExistingConfig() {
 function writeConfig(config) {
     ensureConfigDir();
     const configFilePath = getConfigFilePath();
-    
+
     try {
         fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2), 'utf8');
     } catch (error) {
@@ -72,14 +77,14 @@ function writeConfig(config) {
 // Merge default config with existing config
 function mergeWithDefaults(existingConfig) {
     const mergedConfig = { ...DEFAULT_CONFIG };
-    
+
     // Add any existing values that match default keys
     for (const key in DEFAULT_CONFIG) {
         if (existingConfig.hasOwnProperty(key)) {
             mergedConfig[key] = existingConfig[key];
         }
     }
-    
+
     return mergedConfig;
 }
 
@@ -88,21 +93,21 @@ function getLocalConfig() {
     try {
         // Ensure config directory exists
         ensureConfigDir();
-        
+
         // Read existing config
         const existingConfig = readExistingConfig();
-        
+
         // Merge with defaults
         const finalConfig = mergeWithDefaults(existingConfig);
-        
+
         // Check if we need to update the config file
         const needsUpdate = JSON.stringify(existingConfig) !== JSON.stringify(finalConfig);
-        
+
         if (needsUpdate) {
             writeConfig(finalConfig);
             console.log('Config updated with missing fields');
         }
-        
+
         return finalConfig;
     } catch (error) {
         console.error('Error in getLocalConfig:', error.message);
@@ -114,5 +119,5 @@ function getLocalConfig() {
 // Export only the necessary functions
 module.exports = {
     getLocalConfig,
-    writeConfig
-}; 
+    writeConfig,
+};


### PR DESCRIPTION
The app now lets you choose which microphone and speaker the application uses from Settings → Customize → Audio & Microphone.

- Selections are persisted to the local app configuration and to renderer `localStorage`, so they survive restarts.
- The selected microphone is used when the app requests audio capture (`getUserMedia`) so your preferred input will be used for transcription and analysis.
- Note: Device labels may be blank until you grant microphone permission; grant access and re-open Settings to see friendly names.