### PR TITLE
[shortcut] Add shortcut to focus textbox input 

### DIFF
--- a/src/components/views/AssistantView.js
+++ b/src/components/views/AssistantView.js
@@ -434,11 +434,16 @@ export class AssistantView extends LitElement {
             this.handleNextResponse = () => this.navigateToNextResponse();
             this.handleScrollUp = () => this.scrollResponseUp();
             this.handleScrollDown = () => this.scrollResponseDown();
+            this.handleFocusInput = () => {
+                const textInput = this.shadowRoot.querySelector('#textInput');
+                if (textInput) textInput.focus();
+            };
 
             ipcRenderer.on('navigate-previous-response', this.handlePreviousResponse);
             ipcRenderer.on('navigate-next-response', this.handleNextResponse);
             ipcRenderer.on('scroll-response-up', this.handleScrollUp);
             ipcRenderer.on('scroll-response-down', this.handleScrollDown);
+            ipcRenderer.on('focus-input', this.handleFocusInput);
         }
     }
 
@@ -452,6 +457,7 @@ export class AssistantView extends LitElement {
             if (this.handleNextResponse) ipcRenderer.removeListener('navigate-next-response', this.handleNextResponse);
             if (this.handleScrollUp) ipcRenderer.removeListener('scroll-response-up', this.handleScrollUp);
             if (this.handleScrollDown) ipcRenderer.removeListener('scroll-response-down', this.handleScrollDown);
+            if (this.handleFocusInput) ipcRenderer.removeListener('focus-input', this.handleFocusInput);
         }
     }
 

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -303,6 +303,7 @@ export class CustomizeView extends LitElement {
             nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
             scrollUp: isMac ? 'Cmd+Shift+Up' : 'Ctrl+Shift+Up',
             scrollDown: isMac ? 'Cmd+Shift+Down' : 'Ctrl+Shift+Down',
+            focusInput: isMac ? 'Cmd+L' : 'Ctrl+L',
         };
     }
 
@@ -319,6 +320,7 @@ export class CustomizeView extends LitElement {
             { key: 'nextResponse', name: 'Next Response', description: 'Move to next AI response' },
             { key: 'scrollUp', name: 'Scroll Response Up', description: 'Scroll response content upward' },
             { key: 'scrollDown', name: 'Scroll Response Down', description: 'Scroll response content downward' },
+            { key: 'focusInput', name: 'Focus Input', description: 'Focus the text input box' },
         ];
     }
 

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -107,6 +107,7 @@ function getDefaultKeybinds() {
         nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
         scrollUp: isMac ? 'Cmd+Shift+Up' : 'Ctrl+Shift+Up',
         scrollDown: isMac ? 'Cmd+Shift+Down' : 'Ctrl+Shift+Down',
+        focusInput: isMac ? 'Cmd+L' : 'Ctrl+L',
         emergencyErase: isMac ? 'Cmd+Shift+E' : 'Ctrl+Shift+E',
     };
 }
@@ -267,6 +268,25 @@ function updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessi
             console.log(`Registered scrollDown: ${keybinds.scrollDown}`);
         } catch (error) {
             console.error(`Failed to register scrollDown (${keybinds.scrollDown}):`, error);
+        }
+    }
+
+    // Register focus input shortcut
+    if (keybinds.focusInput) {
+        try {
+            globalShortcut.register(keybinds.focusInput, () => {
+                console.log('Focus input shortcut triggered');
+                if (!mainWindow.isVisible()) {
+                    mainWindow.show();
+                } else {
+                    mainWindow.focus();
+                }
+                mainWindow.webContents.focus();
+                mainWindow.webContents.send('focus-input');
+            });
+            console.log(`Registered focusInput: ${keybinds.focusInput}`);
+        } catch (error) {
+            console.error(`Failed to register focusInput (${keybinds.focusInput}):`, error);
         }
     }
 


### PR DESCRIPTION
Add keyboard shortcut to focus textbox input

Default is Cmd+L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to quickly focus the text input box (Cmd+L on macOS, Ctrl+L on Windows/Linux). The shortcut is customizable in the application's keyboard shortcuts settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->