### PR TITLE
Add microphone device selection and permission handling

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -24,6 +24,7 @@ const DEFAULT_PREFERENCES = {
     selectedImageQuality: 'medium',
     advancedMode: false,
     audioMode: 'speaker_only',
+    audioInputDeviceId: '',
     fontSize: 'medium',
     backgroundTransparency: 0.8,
     googleSearchEnabled: false,


### PR DESCRIPTION
### Problem

Some mics (e.g. Logitech G733) didn’t work: the app didn’t ask for permission in a way that exposes the device list, so sessions could fail.

### What changed

- Settings → Audio: “Allow access & list devices” triggers the system mic permission; user can then choose the device (e.g. G733). Choice is saved.
- Session start: On Windows, mic is requested first (with saved device), then screen — so the permission dialog shows when you click Start.
- Fallback: If screen+audio fails, we retry with screen-only so the session still starts.
- UI: Device list is a dark-themed custom dropdown so it’s readable in the overlay.
- Files: src/storage.js, src/utils/renderer.js, src/components/views/CustomizeView.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added microphone device selection dropdown in audio settings for choosing preferred input devices.
  * System automatically detects available audio input devices and handles permission requests.
  * Enhanced audio capture workflow with improved microphone handling across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->