### PR TITLE
fix: mix L/R channels when converting system audio to mono

### DIFF
--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -746,7 +746,9 @@ function convertStereoToMono(stereoBuffer) {
 
     for (let i = 0; i < samples; i++) {
         const leftSample = stereoBuffer.readInt16LE(i * 4);
-        monoBuffer.writeInt16LE(leftSample, i * 2);
+        const rightSample = stereoBuffer.readInt16LE(i * 4 + 2);
+        const mixedSample = Math.round((leftSample + rightSample) / 2);
+        monoBuffer.writeInt16LE(mixedSample, i * 2);
     }
 
     return monoBuffer;


### PR DESCRIPTION
## What
This PR fixes mono conversion in the macOS system-audio path so both stereo channels are used.

## Why
Root cause: `convertStereoToMono()` was reading only the left channel and discarding the right channel.
On some setups, useful signal is mostly on the right channel, which caused very low/empty audio input.

## Change
Updated `convertStereoToMono()` in `src/utils/gemini.js` to downmix stereo frames as:
`mono = round((left + right) / 2)`

## Scope
- File: `src/utils/gemini.js`
- Function: `convertStereoToMono`
- Commit: `97f23eb`

## Validation
- Verified code path in macOS SystemAudioDump flow.
- Confirmed only this change is included (isolated fix).

## Risk
Low. Change is localized to stereo->mono conversion and does not alter IPC/session flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stereo to mono audio conversion to properly blend both channels for improved audio quality, replacing the previous method that used only a single channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->