### PR TITLE
Add capture display selection setting

### DIFF
--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -216,7 +216,7 @@ export class CustomizeView extends LitElement {
         this.audioMode = 'speaker_only';
         this.customPrompt = '';
         this.theme = 'dark';
-        this.captureDisplayIndex = 0;
+        this.captureDisplayId = '';
         this.availableDisplays = [];
         this._loadFromStorage();
         this._loadDisplaySources();
@@ -235,7 +235,7 @@ export class CustomizeView extends LitElement {
             this.audioMode = prefs.audioMode ?? 'speaker_only';
             this.customPrompt = prefs.customPrompt ?? '';
             this.theme = prefs.theme ?? 'dark';
-            this.captureDisplayIndex = prefs.captureDisplayIndex ?? 0;
+            this.captureDisplayId = prefs.captureDisplayId ?? '';
             if (keybinds) {
                 this.keybinds = { ...this.getDefaultKeybinds(), ...keybinds };
             }
@@ -380,8 +380,8 @@ export class CustomizeView extends LitElement {
     }
 
     async handleCaptureDisplaySelect(e) {
-        this.captureDisplayIndex = parseInt(e.target.value, 10);
-        await cheatingDaddy.storage.updatePreference('captureDisplayIndex', this.captureDisplayIndex);
+        this.captureDisplayId = e.target.value;
+        await cheatingDaddy.storage.updatePreference('captureDisplayId', this.captureDisplayId);
     }
 
     async handleThemeChange(e) {
@@ -513,6 +513,7 @@ export class CustomizeView extends LitElement {
                 backgroundTransparency: 0.8,
                 googleSearchEnabled: false,
                 theme: 'dark',
+                captureDisplayId: '',
             };
             for (const [key, value] of Object.entries(defaults)) {
                 await cheatingDaddy.storage.updatePreference(key, value);
@@ -536,6 +537,7 @@ export class CustomizeView extends LitElement {
             this.googleSearchEnabled = defaults.googleSearchEnabled;
             this.customPrompt = defaults.customPrompt;
             this.theme = defaults.theme;
+            this.captureDisplayId = defaults.captureDisplayId;
 
             // Notify parent callbacks
             this.onProfileChange(defaults.selectedProfile);
@@ -616,10 +618,10 @@ export class CustomizeView extends LitElement {
                     </div>
                     <div class="form-group">
                         <label class="form-label">Capture Display</label>
-                        <select class="control" .value=${String(this.captureDisplayIndex)} @change=${this.handleCaptureDisplaySelect}>
+                        <select class="control" .value=${this.captureDisplayId} @change=${this.handleCaptureDisplaySelect}>
                             ${this.availableDisplays.length > 0
-                                ? this.availableDisplays.map(d => html`<option value=${d.index}>${d.name}</option>`)
-                                : html`<option value="0">Display 1 (default)</option>`
+                                ? this.availableDisplays.map(d => html`<option value=${d.id}>${d.name}</option>`)
+                                : html`<option value="">Display 1 (default)</option>`
                             }
                         </select>
                     </div>

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -216,7 +216,10 @@ export class CustomizeView extends LitElement {
         this.audioMode = 'speaker_only';
         this.customPrompt = '';
         this.theme = 'dark';
+        this.captureDisplayIndex = 0;
+        this.availableDisplays = [];
         this._loadFromStorage();
+        this._loadDisplaySources();
     }
 
     getThemes() {
@@ -232,6 +235,7 @@ export class CustomizeView extends LitElement {
             this.audioMode = prefs.audioMode ?? 'speaker_only';
             this.customPrompt = prefs.customPrompt ?? '';
             this.theme = prefs.theme ?? 'dark';
+            this.captureDisplayIndex = prefs.captureDisplayIndex ?? 0;
             if (keybinds) {
                 this.keybinds = { ...this.getDefaultKeybinds(), ...keybinds };
             }
@@ -359,6 +363,25 @@ export class CustomizeView extends LitElement {
         this.audioMode = e.target.value;
         await cheatingDaddy.storage.updatePreference('audioMode', this.audioMode);
         this.requestUpdate();
+    }
+
+    async _loadDisplaySources() {
+        if (!window.require) return;
+        try {
+            const { ipcRenderer } = window.require('electron');
+            const result = await ipcRenderer.invoke('get-display-sources');
+            if (result.success) {
+                this.availableDisplays = result.data;
+                this.requestUpdate();
+            }
+        } catch (error) {
+            console.error('Error loading display sources:', error);
+        }
+    }
+
+    async handleCaptureDisplaySelect(e) {
+        this.captureDisplayIndex = parseInt(e.target.value, 10);
+        await cheatingDaddy.storage.updatePreference('captureDisplayIndex', this.captureDisplayIndex);
     }
 
     async handleThemeChange(e) {
@@ -589,6 +612,15 @@ export class CustomizeView extends LitElement {
                             <option value="high">High Quality</option>
                             <option value="medium">Medium Quality</option>
                             <option value="low">Low Quality</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Capture Display</label>
+                        <select class="control" .value=${String(this.captureDisplayIndex)} @change=${this.handleCaptureDisplaySelect}>
+                            ${this.availableDisplays.length > 0
+                                ? this.availableDisplays.map(d => html`<option value=${d.index}>${d.name}</option>`)
+                                : html`<option value="0">Display 1 (default)</option>`
+                            }
                         </select>
                     </div>
                 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -263,6 +263,36 @@ function setupGeneralIpcHandlers() {
         return app.getVersion();
     });
 
+    ipcMain.handle('get-display-sources', async () => {
+        try {
+            const { desktopCapturer, screen } = require('electron');
+            const [sources, displays] = await Promise.all([
+                desktopCapturer.getSources({ types: ['screen'] }),
+                Promise.resolve(screen.getAllDisplays()),
+            ]);
+            const displayById = new Map(displays.map(d => [String(d.id), d]));
+            const data = sources.map((s, i) => {
+                const display = displayById.get(String(s.display_id));
+                let name;
+                if (display) {
+                    const { width, height } = display.bounds;
+                    const tag = display.internal ? 'Built-in' : 'External';
+                    const label = display.label && display.label !== s.name ? display.label : null;
+                    name = label
+                        ? `${tag}: ${label} (${width}×${height})`
+                        : `${tag}: ${s.name} (${width}×${height})`;
+                } else {
+                    name = s.name || `Display ${i + 1}`;
+                }
+                return { index: i, name, id: s.id };
+            });
+            return { success: true, data };
+        } catch (error) {
+            console.error('Error getting display sources:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('quit-application', async event => {
         try {
             stopMacOSAudioCapture();

--- a/src/storage.js
+++ b/src/storage.js
@@ -30,6 +30,7 @@ const DEFAULT_PREFERENCES = {
     ollamaHost: 'http://127.0.0.1:11434',
     ollamaModel: 'llama3.1',
     whisperModel: 'Xenova/whisper-small',
+    captureDisplayIndex: 0,
 };
 
 const DEFAULT_KEYBINDS = null; // null means use system defaults

--- a/src/storage.js
+++ b/src/storage.js
@@ -30,7 +30,7 @@ const DEFAULT_PREFERENCES = {
     ollamaHost: 'http://127.0.0.1:11434',
     ollamaModel: 'llama3.1',
     whisperModel: 'Xenova/whisper-small',
-    captureDisplayIndex: 0,
+    captureDisplayId: '',
 };
 
 const DEFAULT_KEYBINDS = null; // null means use system defaults

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -32,8 +32,8 @@ function createWindow(sendToRenderer, geminiSessionRef) {
         (request, callback) => {
             desktopCapturer.getSources({ types: ['screen'] }).then(sources => {
                 const prefs = storage.getPreferences();
-                const displayIndex = prefs.captureDisplayIndex || 0;
-                const source = sources[displayIndex] || sources[0];
+                const savedId = prefs.captureDisplayId;
+                const source = (savedId && sources.find(s => s.id === savedId)) || sources[0];
                 callback({ video: source, audio: 'loopback' });
             });
         },
@@ -304,23 +304,23 @@ function updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessi
 function setupWindowIpcHandlers(mainWindow, sendToRenderer, geminiSessionRef) {
     ipcMain.on('view-changed', (event, view) => {
         if (!mainWindow.isDestroyed()) {
-            const primaryDisplay = screen.getPrimaryDisplay();
-            const { width: screenWidth } = primaryDisplay.workAreaSize;
+            const currentDisplay = screen.getDisplayNearestPoint(mainWindow.getBounds());
+            const { x: dispX, width: screenWidth } = currentDisplay.workArea;
 
             if (view === 'assistant') {
                 // Shrink window for live view
                 const liveWidth = 850;
                 const liveHeight = 400;
-                const x = Math.floor((screenWidth - liveWidth) / 2);
+                const x = dispX + Math.floor((screenWidth - liveWidth) / 2);
                 mainWindow.setSize(liveWidth, liveHeight);
-                mainWindow.setPosition(x, 0);
+                mainWindow.setPosition(x, currentDisplay.workArea.y);
             } else {
                 // Restore full size
                 const fullWidth = 1100;
                 const fullHeight = 800;
-                const x = Math.floor((screenWidth - fullWidth) / 2);
+                const x = dispX + Math.floor((screenWidth - fullWidth) / 2);
                 mainWindow.setSize(fullWidth, fullHeight);
-                mainWindow.setPosition(x, 0);
+                mainWindow.setPosition(x, currentDisplay.workArea.y);
                 mainWindow.setIgnoreMouseEvents(false);
             }
         }

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -31,10 +31,13 @@ function createWindow(sendToRenderer, geminiSessionRef) {
     session.defaultSession.setDisplayMediaRequestHandler(
         (request, callback) => {
             desktopCapturer.getSources({ types: ['screen'] }).then(sources => {
-                callback({ video: sources[0], audio: 'loopback' });
+                const prefs = storage.getPreferences();
+                const displayIndex = prefs.captureDisplayIndex || 0;
+                const source = sources[displayIndex] || sources[0];
+                callback({ video: source, audio: 'loopback' });
             });
         },
-        { useSystemPicker: true }
+        { useSystemPicker: false }
     );
 
     mainWindow.setResizable(false);


### PR DESCRIPTION
## Summary

- Adds a **Capture Display** dropdown to Settings → Audio Input so users can select which monitor to use for Cmd+Enter screen analysis
- Display names are enriched with Built-in/External label and resolution (e.g. `Built-in: Built-in Retina Display (2560×1600)`, `External: LG Ultra HD (3840×2160)`)
- Fixes the root cause of screen analysis always capturing the laptop display (`sources[0]` was hardcoded)

## Test plan

- [ ] Open Settings → Audio Input — confirm "Capture Display" dropdown appears with all connected monitors listed
- [ ] Select external monitor from the dropdown
- [ ] Press Cmd+Enter — confirm the screenshot is taken from the external monitor
- [ ] Verify default (index 0) still works when no preference is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a display selection in customization: choose which monitor to capture via a saved dropdown; selection is persisted and restored.

* **Improvements**
  * Screen capture now directly uses the chosen display (no extra picker) for cleaner recording setup.
  * Window positioning when switching views now centers windows on the display they appear on for more consistent layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->