### PR TITLE
fix: Windows local AI mode - screen capture, Whisper crash & noise filtering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ if (require('electron-squirrel-startup')) {
 }
 
 const { app, BrowserWindow, shell, ipcMain } = require('electron');
+
+// Fix DXGI screen capture failure on multi-GPU Windows setups
+if (process.platform === 'win32') {
+    app.commandLine.appendSwitch('disable-gpu-sandbox');
+}
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
 const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
 const storage = require('./storage');
@@ -261,6 +266,16 @@ function setupStorageIpcHandlers() {
 function setupGeneralIpcHandlers() {
     ipcMain.handle('get-app-version', async () => {
         return app.getVersion();
+    });
+
+    ipcMain.handle('get-desktop-sources', async () => {
+        try {
+            const { desktopCapturer } = require('electron');
+            const sources = await desktopCapturer.getSources({ types: ['screen'] });
+            return sources.map(s => ({ id: s.id, name: s.name }));
+        } catch (e) {
+            return [];
+        }
     });
 
     ipcMain.handle('quit-application', async event => {

--- a/src/utils/localai.js
+++ b/src/utils/localai.js
@@ -130,7 +130,7 @@ async function loadWhisperPipeline(modelName) {
         env.cacheDir = path.join(app.getPath('userData'), 'whisper-models');
         whisperPipeline = await pipeline('automatic-speech-recognition', modelName, {
             dtype: 'q8',
-            device: 'auto',
+            device: 'cpu',
         });
         console.log('[LocalAI] Whisper model loaded successfully');
         sendToRenderer('whisper-downloading', false);
@@ -195,6 +195,14 @@ async function handleSpeechEnd(audioData) {
 
     if (!transcription || transcription.trim() === '' || transcription.trim().length < 2) {
         console.log('[LocalAI] Empty transcription, skipping');
+        sendToRenderer('update-status', 'Listening...');
+        return;
+    }
+
+    // Filter out Whisper noise artifacts: [BLANK_AUDIO], (clinking), (clicking), etc.
+    const cleaned = transcription.trim();
+    if (cleaned === '[BLANK_AUDIO]' || /^\[.*\]$/.test(cleaned) || /^\(.*\)$/.test(cleaned)) {
+        console.log('[LocalAI] Noise artifact, skipping:', cleaned);
         sendToRenderer('update-status', 'Listening...');
         return;
     }

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -310,58 +310,82 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
             console.log('Linux capture started - system audio:', mediaStream.getAudioTracks().length > 0, 'microphone mode:', audioMode);
         } else {
             // Windows - use display media with loopback for system audio
-            mediaStream = await navigator.mediaDevices.getDisplayMedia({
-                video: {
-                    frameRate: 1,
-                    width: { ideal: 1920 },
-                    height: { ideal: 1080 },
-                },
-                audio: {
-                    sampleRate: SAMPLE_RATE,
-                    channelCount: 1,
-                    echoCancellation: true,
-                    noiseSuppression: true,
-                    autoGainControl: true,
-                },
-            });
+            try {
+                mediaStream = await navigator.mediaDevices.getDisplayMedia({
+                    video: {
+                        frameRate: 1,
+                        width: { ideal: 1920 },
+                        height: { ideal: 1080 },
+                    },
+                    audio: {
+                        sampleRate: SAMPLE_RATE,
+                        channelCount: 1,
+                        echoCancellation: true,
+                        noiseSuppression: true,
+                        autoGainControl: true,
+                    },
+                });
 
-            console.log('Windows capture started with loopback audio');
+                console.log('Windows capture started with loopback audio');
+                setupWindowsLoopbackProcessing();
+            } catch (displayErr) {
+                console.warn('getDisplayMedia failed, trying getUserMedia with desktop source:', displayErr);
 
-            // Setup audio processing for Windows loopback audio only
-            setupWindowsLoopbackProcessing();
-
-            if (audioMode === 'mic_only' || audioMode === 'both') {
-                let micStream = null;
                 try {
-                    micStream = await navigator.mediaDevices.getUserMedia({
-                        audio: {
-                            sampleRate: SAMPLE_RATE,
-                            channelCount: 1,
-                            echoCancellation: true,
-                            noiseSuppression: true,
-                            autoGainControl: true,
-                        },
-                        video: false,
-                    });
-                    console.log('Windows microphone capture started');
-                    setupLinuxMicProcessing(micStream);
-                } catch (micError) {
-                    console.warn('Failed to get microphone access on Windows:', micError);
+                    const sources = await ipcRenderer.invoke('get-desktop-sources');
+                    if (sources && sources.length > 0) {
+                        mediaStream = await navigator.mediaDevices.getUserMedia({
+                            audio: false,
+                            video: {
+                                mandatory: {
+                                    chromeMediaSource: 'desktop',
+                                    chromeMediaSourceId: sources[0].id,
+                                    maxWidth: 1920,
+                                    maxHeight: 1080,
+                                    maxFrameRate: 1,
+                                },
+                            },
+                        });
+                        console.log('Windows capture started via desktopCapturer fallback (no audio)');
+                    } else {
+                        console.warn('No desktop sources found, mic-only mode');
+                    }
+                } catch (fallbackErr) {
+                    console.warn('Desktop capture fallback failed, mic-only mode:', fallbackErr);
                 }
+            }
+
+            // Always try microphone (required for local AI mode when screen capture fails)
+            try {
+                const micStream = await navigator.mediaDevices.getUserMedia({
+                    audio: {
+                        sampleRate: SAMPLE_RATE,
+                        channelCount: 1,
+                        echoCancellation: true,
+                        noiseSuppression: true,
+                        autoGainControl: true,
+                    },
+                    video: false,
+                });
+                console.log('Windows microphone capture started');
+                setupLinuxMicProcessing(micStream);
+            } catch (micError) {
+                console.warn('Failed to get microphone access on Windows:', micError);
             }
         }
 
-        console.log('MediaStream obtained:', {
-            hasVideo: mediaStream.getVideoTracks().length > 0,
-            hasAudio: mediaStream.getAudioTracks().length > 0,
-            videoTrack: mediaStream.getVideoTracks()[0]?.getSettings(),
-        });
+        if (mediaStream) {
+            console.log('MediaStream obtained:', {
+                hasVideo: mediaStream.getVideoTracks().length > 0,
+                hasAudio: mediaStream.getAudioTracks().length > 0,
+                videoTrack: mediaStream.getVideoTracks()[0]?.getSettings(),
+            });
+        }
 
         // Manual mode only - screenshots captured on demand via shortcut
         console.log('Manual mode enabled - screenshots will be captured on demand only');
     } catch (err) {
         console.error('Error starting capture:', err);
-        cheatingDaddy.setStatus('error');
     }
 }
 

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -31,10 +31,14 @@ function createWindow(sendToRenderer, geminiSessionRef) {
     session.defaultSession.setDisplayMediaRequestHandler(
         (request, callback) => {
             desktopCapturer.getSources({ types: ['screen'] }).then(sources => {
-                callback({ video: sources[0], audio: 'loopback' });
-            });
+                if (sources.length > 0) {
+                    callback({ video: sources[0], audio: 'loopback' });
+                } else {
+                    callback({});
+                }
+            }).catch(() => callback({}));
         },
-        { useSystemPicker: true }
+        { useSystemPicker: false }
     );
 
     mainWindow.setResizable(false);


### PR DESCRIPTION
## What was broken

Tested on Windows 11 with RTX 3080 Mobile + multi-GPU setup (DXGI adapter 2 present).

### 1. Whisper crashed the entire Electron process on startup
`device: 'auto'` in `loadWhisperPipeline` caused ONNX Runtime to attempt DirectML/GPU acceleration on Windows. This is a **native crash** — it kills the whole process and is not caught by `try/catch`.

**Fix:** Changed `device: 'auto'` → `device: 'cpu'` in `localai.js`.

### 2. Screen capture failed silently on multi-GPU Windows machines
`getDisplayMedia` with `useSystemPicker: true` triggered DXGI enumeration across all GPU adapters. On systems with a secondary/virtual adapter (adapter 2), this causes a `DOMException` **before the picker dialog even appears** — so users see nothing and the session starts with no screen capture.

**Fix (two-part):**
- `window.js`: switched to `useSystemPicker: false` so Electron handles source selection internally without triggering full DXGI enumeration
- `renderer.js`: added a fallback — when `getDisplayMedia` fails, automatically retries using `desktopCapturer.getSources()` + `getUserMedia` with `chromeMediaSourceId`. This bypasses the problematic DXGI path and successfully captures the screen.
- Added `get-desktop-sources` IPC handler in `index.js`
- Added `disable-gpu-sandbox` flag on Windows to help with GPU sandbox issues
- Guarded `mediaStream.getVideoTracks()` call against null when fallback is active

### 3. Whisper noise artifacts sent to Ollama
Whisper regularly outputs `[BLANK_AUDIO]`, `(clicking)`, `(clinking)`, `(clattering)`, `[MUSIC]` etc. for background noise. These were being forwarded to Ollama as real transcriptions, wasting context and producing nonsense responses.

**Fix:** Added a filter in `handleSpeechEnd` that skips any transcription matching `[...]` or `(...)` patterns, or equal to `[BLANK_AUDIO]`.

### 4. Microphone now always initialized on Windows
Previously the mic was only set up when `audioMode === 'mic_only' || 'both'`. In local AI mode the mic is the primary audio source, so it's now always initialized regardless of `audioMode` setting.

## Result
Local AI mode on Windows now works end-to-end: Whisper loads, screen is captured (with automatic fallback), screenshots via Ctrl+Enter work, and noise artifacts are filtered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen capture reliability on Windows multi-GPU setups
  * Enhanced microphone audio capture with better fallback handling
  * Added noise filtering to remove blank audio artifacts from transcriptions

* **Improvements**
  * Optimized speech recognition to use CPU-based processing for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->