### PR TITLE
Fix deprecated Gemini/Gemma model names

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -36,7 +36,7 @@ const DEFAULT_PREFERENCES = {
 const DEFAULT_KEYBINDS = null; // null means use system defaults
 
 const DEFAULT_LIMITS = {
-    data: [] // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-3-27b-it': { chars } } }
+    data: [] // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-4-26b-a4b-it': { chars } } }
 };
 
 // Get the config directory path based on OS
@@ -268,7 +268,7 @@ function getTodayLimits() {
         }
         if(!todayEntry.gemini) {
             todayEntry.gemini = {
-                'gemma-3-27b-it': { chars: 0 }
+                'gemma-4-26b-a4b-it': { chars: 0 }
             };
         }
         setLimits(limits);
@@ -288,7 +288,7 @@ function getTodayLimits() {
             'kimi-k2-instruct': { chars: 0, limit: 600000 }
         },
         gemini: {
-            'gemma-3-27b-it': { chars: 0 }
+            'gemma-4-26b-a4b-it': { chars: 0 }
         }
     };
     limits.data.push(newEntry);

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -382,7 +382,7 @@ async function sendToGemma(transcription) {
         ];
 
         const response = await ai.models.generateContentStream({
-            model: 'gemma-3-27b-it',
+            model: 'gemma-4-26b-a4b-it',
             contents: messagesWithSystem,
         });
 
@@ -403,7 +403,7 @@ async function sendToGemma(transcription) {
         const inputChars = systemPromptChars + historyChars;
         const outputChars = fullText.length;
 
-        incrementCharUsage('gemini', 'gemma-3-27b-it', inputChars + outputChars);
+        incrementCharUsage('gemini', 'gemma-4-26b-a4b-it', inputChars + outputChars);
 
         if (fullText.trim()) {
             groqConversationHistory.push({
@@ -464,7 +464,7 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
 
     try {
         const session = await client.live.connect({
-            model: 'gemini-2.5-flash-native-audio-preview-09-2025',
+            model: 'gemini-3.1-flash-live-preview',
             callbacks: {
                 onopen: function () {
                     sendToRenderer('update-status', 'Live session connected');


### PR DESCRIPTION
## Summary
- `gemma-3-27b-it` returns 404 (retired) — switched Gemma fallback model to `gemma-4-26b-a4b-it`
- `gemini-2.5-flash-native-audio-preview-09-2025` deprecated — switched live session model to `gemini-3.1-flash-live-preview`
- Updated default storage shape/usage-tracking key to match new Gemma model name

## Test plan
- [x] Started a live session, verified `setupComplete` and audio transcription work with new live model
- [x] Triggered Gemma fallback path (no Groq key), verified it streams a response without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model versions for text generation and real-time audio features to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->