### PR TITLE
fix: resolve Free Tier Live API quota crash when Google Search is enabled

### DIFF
--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -464,7 +464,7 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
 
     try {
         const session = await client.live.connect({
-            model: 'gemini-3.1-flash-live-preview',
+            model: 'gemini-2.5-flash-native-audio-preview-12-2025',
             callbacks: {
                 onopen: function () {
                     sendToRenderer('update-status', 'Live session connected');


### PR DESCRIPTION
### Description
This PR resolves a WebSocket connection crash (Code 1011) that occurs on Google AI Studio Free Tier accounts when using the Live API with search grounding enabled.

### Problem
- The application was hardcoded to use `gemini-3.1-flash-live-preview` for real-time WebSocket communication.
- On the Free Tier, Google restricts the `gemini-3.1-flash-live-preview` model from combining with the Google Search grounding tool (it has a tight 65K TPM limit, and search grounding throws quota exceptions).
- When a user starts a session with Google Search toggled on, the server immediately drops the connection with the error:
  `Session closed: You exceeded your current quota, please check your plan and billing details.`

### Solution
- Switched the Live API model ID to `gemini-2.5-flash-native-audio-preview-12-2025` (representing *Gemini 2.5 Flash Native Audio Dialog*).
- This model supports Google Search grounding tools natively on the Free Tier under its 1,000,000 TPM limit, enabling both real-time voice streaming and web search to function together without quota crashes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model configuration for real-time conversation features to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->