### PR TITLE
fix(capture): support selecting a display

### DIFF
--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -229,16 +229,17 @@ export class CustomizeView extends LitElement {
 
     async _loadFromStorage() {
         try {
-            const [prefs, keybinds, captureDisplays] = await Promise.all([
-                cheatingDaddy.storage.getPreferences(),
-                cheatingDaddy.storage.getKeybinds(),
-                cheatingDaddy.getCaptureDisplays(),
-            ]);
+            const [prefs, keybinds] = await Promise.all([cheatingDaddy.storage.getPreferences(), cheatingDaddy.storage.getKeybinds()]);
+            try {
+                this.captureDisplays = (await cheatingDaddy.getCaptureDisplays()) || [];
+            } catch (error) {
+                console.error('Error loading capture displays:', error);
+                this.captureDisplays = [];
+            }
             this.googleSearchEnabled = prefs.googleSearchEnabled ?? true;
             this.backgroundTransparency = prefs.backgroundTransparency ?? 0.8;
             this.fontSize = prefs.fontSize ?? 20;
             this.audioMode = prefs.audioMode ?? 'speaker_only';
-            this.captureDisplays = captureDisplays;
             this.selectedCaptureDisplay = prefs.captureDisplayId ?? '';
             this.customPrompt = prefs.customPrompt ?? '';
             this.theme = prefs.theme ?? 'dark';
@@ -597,13 +598,9 @@ export class CustomizeView extends LitElement {
                             <option value="both">Both Speaker and Microphone</option>
                         </select>
                     </div>
-                    ${
-                        this.audioMode !== 'speaker_only'
-                            ? html`
-                                  <div class="warning-callout">May cause unexpected behavior. Only change this if you know what you're doing.</div>
-                              `
-                            : ''
-                    }
+                    ${this.audioMode !== 'speaker_only' ? html`
+                        <div class="warning-callout">May cause unexpected behavior. Only change this if you know what you're doing.</div>
+                    ` : ''}
                     <div class="form-group">
                         <label class="form-label">Image Quality</label>
                         <select class="control" .value=${this.selectedImageQuality} @change=${this.handleImageQualitySelect}>
@@ -616,13 +613,11 @@ export class CustomizeView extends LitElement {
                         <label class="form-label">Capture Display</label>
                         <select class="control" .value=${this.selectedCaptureDisplay} @change=${this.handleCaptureDisplaySelect}>
                             <option value="">Primary display (automatic)</option>
-                            ${this.captureDisplays.map(
-                                display => html`
-                                    <option value=${display.id}>
-                                        ${display.label} (${display.width}×${display.height})${display.isPrimary ? ' — Primary' : ''}
-                                    </option>
-                                `
-                            )}
+                            ${this.captureDisplays.map(display => html`
+                                <option value=${display.id}>
+                                    ${display.label} (${display.width}×${display.height})${display.isPrimary ? ' — Primary' : ''}
+                                </option>
+                            `)}
                         </select>
                     </div>
                 </div>
@@ -696,22 +691,20 @@ export class CustomizeView extends LitElement {
         return html`
             <section class="surface">
                 <div class="surface-title">Keyboard Shortcuts</div>
-                ${this.getKeybindActions().map(
-                    action => html`
-                        <div class="keybind-row">
-                            <span class="keybind-name">${action.name}</span>
-                            <input
-                                type="text"
-                                class="control keybind-input"
-                                .value=${this.keybinds[action.key]}
-                                data-action=${action.key}
-                                @keydown=${this.handleKeybindInput}
-                                @focus=${this.handleKeybindFocus}
-                                readonly
-                            />
-                        </div>
-                    `
-                )}
+                ${this.getKeybindActions().map(action => html`
+                    <div class="keybind-row">
+                        <span class="keybind-name">${action.name}</span>
+                        <input
+                            type="text"
+                            class="control keybind-input"
+                            .value=${this.keybinds[action.key]}
+                            data-action=${action.key}
+                            @keydown=${this.handleKeybindInput}
+                            @focus=${this.handleKeybindFocus}
+                            readonly
+                        />
+                    </div>
+                `)}
                 <div style="margin-top: var(--space-sm);">
                     <button class="control" style="width:auto;padding:8px 10px;" @click=${this.resetKeybinds}>Reset to defaults</button>
                 </div>
@@ -731,11 +724,9 @@ export class CustomizeView extends LitElement {
                         ${this.isClearing ? 'Clearing...' : 'Delete all data'}
                     </button>
                 </div>
-                ${
-                    this.clearStatusMessage
-                        ? html` <div class="status ${this.clearStatusType === 'success' ? 'success' : 'error'}">${this.clearStatusMessage}</div> `
-                        : ''
-                }
+                ${this.clearStatusMessage ? html`
+                    <div class="status ${this.clearStatusType === 'success' ? 'success' : 'error'}">${this.clearStatusMessage}</div>
+                ` : ''}
             </section>
         `;
     }
@@ -745,7 +736,10 @@ export class CustomizeView extends LitElement {
             <div class="unified-page">
                 <div class="unified-wrap">
                     <div class="page-title">Settings</div>
-                    ${this.renderAudioSection()} ${this.renderLanguageSection()} ${this.renderAppearanceSection()} ${this.renderKeyboardSection()}
+                    ${this.renderAudioSection()}
+                    ${this.renderLanguageSection()}
+                    ${this.renderAppearanceSection()}
+                    ${this.renderKeyboardSection()}
                     ${this.renderPrivacySection()}
                 </div>
             </div>

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -179,6 +179,8 @@ export class CustomizeView extends LitElement {
         selectedProfile: { type: String },
         selectedLanguage: { type: String },
         selectedImageQuality: { type: String },
+        captureDisplays: { type: Array },
+        selectedCaptureDisplay: { type: String },
         layoutMode: { type: String },
         keybinds: { type: Object },
         googleSearchEnabled: { type: Boolean },
@@ -200,6 +202,8 @@ export class CustomizeView extends LitElement {
         this.selectedProfile = 'interview';
         this.selectedLanguage = 'en-US';
         this.selectedImageQuality = 'medium';
+        this.captureDisplays = [];
+        this.selectedCaptureDisplay = '';
         this.layoutMode = 'normal';
         this.keybinds = this.getDefaultKeybinds();
         this.onProfileChange = () => {};
@@ -225,11 +229,17 @@ export class CustomizeView extends LitElement {
 
     async _loadFromStorage() {
         try {
-            const [prefs, keybinds] = await Promise.all([cheatingDaddy.storage.getPreferences(), cheatingDaddy.storage.getKeybinds()]);
+            const [prefs, keybinds, captureDisplays] = await Promise.all([
+                cheatingDaddy.storage.getPreferences(),
+                cheatingDaddy.storage.getKeybinds(),
+                cheatingDaddy.getCaptureDisplays(),
+            ]);
             this.googleSearchEnabled = prefs.googleSearchEnabled ?? true;
             this.backgroundTransparency = prefs.backgroundTransparency ?? 0.8;
             this.fontSize = prefs.fontSize ?? 20;
             this.audioMode = prefs.audioMode ?? 'speaker_only';
+            this.captureDisplays = captureDisplays;
+            this.selectedCaptureDisplay = prefs.captureDisplayId ?? '';
             this.customPrompt = prefs.customPrompt ?? '';
             this.theme = prefs.theme ?? 'dark';
             if (keybinds) {
@@ -361,6 +371,11 @@ export class CustomizeView extends LitElement {
         this.requestUpdate();
     }
 
+    async handleCaptureDisplaySelect(e) {
+        this.selectedCaptureDisplay = e.target.value;
+        await cheatingDaddy.storage.updatePreference('captureDisplayId', this.selectedCaptureDisplay);
+    }
+
     async handleThemeChange(e) {
         this.theme = e.target.value;
         await cheatingDaddy.theme.save(this.theme);
@@ -486,6 +501,7 @@ export class CustomizeView extends LitElement {
                 selectedScreenshotInterval: '5',
                 selectedImageQuality: 'medium',
                 audioMode: 'speaker_only',
+                captureDisplayId: '',
                 fontSize: 20,
                 backgroundTransparency: 0.8,
                 googleSearchEnabled: false,
@@ -508,6 +524,7 @@ export class CustomizeView extends LitElement {
             this.selectedLanguage = defaults.selectedLanguage;
             this.selectedImageQuality = defaults.selectedImageQuality;
             this.audioMode = defaults.audioMode;
+            this.selectedCaptureDisplay = defaults.captureDisplayId;
             this.fontSize = defaults.fontSize;
             this.backgroundTransparency = defaults.backgroundTransparency;
             this.googleSearchEnabled = defaults.googleSearchEnabled;
@@ -580,15 +597,32 @@ export class CustomizeView extends LitElement {
                             <option value="both">Both Speaker and Microphone</option>
                         </select>
                     </div>
-                    ${this.audioMode !== 'speaker_only' ? html`
-                        <div class="warning-callout">May cause unexpected behavior. Only change this if you know what you're doing.</div>
-                    ` : ''}
+                    ${
+                        this.audioMode !== 'speaker_only'
+                            ? html`
+                                  <div class="warning-callout">May cause unexpected behavior. Only change this if you know what you're doing.</div>
+                              `
+                            : ''
+                    }
                     <div class="form-group">
                         <label class="form-label">Image Quality</label>
                         <select class="control" .value=${this.selectedImageQuality} @change=${this.handleImageQualitySelect}>
                             <option value="high">High Quality</option>
                             <option value="medium">Medium Quality</option>
                             <option value="low">Low Quality</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Capture Display</label>
+                        <select class="control" .value=${this.selectedCaptureDisplay} @change=${this.handleCaptureDisplaySelect}>
+                            <option value="">Primary display (automatic)</option>
+                            ${this.captureDisplays.map(
+                                display => html`
+                                    <option value=${display.id}>
+                                        ${display.label} (${display.width}×${display.height})${display.isPrimary ? ' — Primary' : ''}
+                                    </option>
+                                `
+                            )}
                         </select>
                     </div>
                 </div>
@@ -662,20 +696,22 @@ export class CustomizeView extends LitElement {
         return html`
             <section class="surface">
                 <div class="surface-title">Keyboard Shortcuts</div>
-                ${this.getKeybindActions().map(action => html`
-                    <div class="keybind-row">
-                        <span class="keybind-name">${action.name}</span>
-                        <input
-                            type="text"
-                            class="control keybind-input"
-                            .value=${this.keybinds[action.key]}
-                            data-action=${action.key}
-                            @keydown=${this.handleKeybindInput}
-                            @focus=${this.handleKeybindFocus}
-                            readonly
-                        />
-                    </div>
-                `)}
+                ${this.getKeybindActions().map(
+                    action => html`
+                        <div class="keybind-row">
+                            <span class="keybind-name">${action.name}</span>
+                            <input
+                                type="text"
+                                class="control keybind-input"
+                                .value=${this.keybinds[action.key]}
+                                data-action=${action.key}
+                                @keydown=${this.handleKeybindInput}
+                                @focus=${this.handleKeybindFocus}
+                                readonly
+                            />
+                        </div>
+                    `
+                )}
                 <div style="margin-top: var(--space-sm);">
                     <button class="control" style="width:auto;padding:8px 10px;" @click=${this.resetKeybinds}>Reset to defaults</button>
                 </div>
@@ -695,9 +731,11 @@ export class CustomizeView extends LitElement {
                         ${this.isClearing ? 'Clearing...' : 'Delete all data'}
                     </button>
                 </div>
-                ${this.clearStatusMessage ? html`
-                    <div class="status ${this.clearStatusType === 'success' ? 'success' : 'error'}">${this.clearStatusMessage}</div>
-                ` : ''}
+                ${
+                    this.clearStatusMessage
+                        ? html` <div class="status ${this.clearStatusType === 'success' ? 'success' : 'error'}">${this.clearStatusMessage}</div> `
+                        : ''
+                }
             </section>
         `;
     }
@@ -707,10 +745,7 @@ export class CustomizeView extends LitElement {
             <div class="unified-page">
                 <div class="unified-wrap">
                     <div class="page-title">Settings</div>
-                    ${this.renderAudioSection()}
-                    ${this.renderLanguageSection()}
-                    ${this.renderAppearanceSection()}
-                    ${this.renderKeyboardSection()}
+                    ${this.renderAudioSection()} ${this.renderLanguageSection()} ${this.renderAppearanceSection()} ${this.renderKeyboardSection()}
                     ${this.renderPrivacySection()}
                 </div>
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ if (require('electron-squirrel-startup')) {
     process.exit(0);
 }
 
-const { app, BrowserWindow, shell, ipcMain } = require('electron');
+const { app, BrowserWindow, shell, ipcMain, screen } = require('electron');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
 const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
 const storage = require('./storage');
@@ -261,6 +261,24 @@ function setupStorageIpcHandlers() {
 function setupGeneralIpcHandlers() {
     ipcMain.handle('get-app-version', async () => {
         return app.getVersion();
+    });
+
+    ipcMain.handle('get-capture-displays', async () => {
+        try {
+            const primaryDisplay = screen.getPrimaryDisplay();
+            const displays = screen.getAllDisplays().map((display, index) => ({
+                id: String(display.id),
+                label: display.label || `Display ${index + 1}`,
+                width: display.size.width,
+                height: display.size.height,
+                scaleFactor: display.scaleFactor,
+                isPrimary: display.id === primaryDisplay.id,
+            }));
+            return { success: true, data: displays };
+        } catch (error) {
+            console.error('Error getting capture displays:', error);
+            return { success: false, error: error.message };
+        }
     });
 
     ipcMain.handle('quit-application', async event => {

--- a/src/storage.js
+++ b/src/storage.js
@@ -8,12 +8,12 @@ const CONFIG_VERSION = 1;
 const DEFAULT_CONFIG = {
     configVersion: CONFIG_VERSION,
     onboarded: false,
-    layout: 'normal',
+    layout: 'normal'
 };
 
 const DEFAULT_CREDENTIALS = {
     apiKey: '',
-    groqApiKey: '',
+    groqApiKey: ''
 };
 
 const DEFAULT_PREFERENCES = {
@@ -37,7 +37,7 @@ const DEFAULT_PREFERENCES = {
 const DEFAULT_KEYBINDS = null; // null means use system defaults
 
 const DEFAULT_LIMITS = {
-    data: [], // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-4-26b-a4b-it': { chars } } }
+    data: [] // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-4-26b-a4b-it': { chars } } }
 };
 
 // Get the config directory path based on OS
@@ -259,17 +259,17 @@ function getTodayLimits() {
 
     if (todayEntry) {
         // ensure new fields exist
-        if (!todayEntry.groq) {
+        if(!todayEntry.groq) {
             todayEntry.groq = {
                 'qwen3-32b': { chars: 0, limit: 1500000 },
                 'gpt-oss-120b': { chars: 0, limit: 600000 },
                 'gpt-oss-20b': { chars: 0, limit: 600000 },
-                'kimi-k2-instruct': { chars: 0, limit: 600000 },
+                'kimi-k2-instruct': { chars: 0, limit: 600000 }
             };
         }
-        if (!todayEntry.gemini) {
+        if(!todayEntry.gemini) {
             todayEntry.gemini = {
-                'gemma-4-26b-a4b-it': { chars: 0 },
+                'gemma-4-26b-a4b-it': { chars: 0 }
             };
         }
         setLimits(limits);
@@ -286,11 +286,11 @@ function getTodayLimits() {
             'qwen3-32b': { chars: 0, limit: 1500000 },
             'gpt-oss-120b': { chars: 0, limit: 600000 },
             'gpt-oss-20b': { chars: 0, limit: 600000 },
-            'kimi-k2-instruct': { chars: 0, limit: 600000 },
+            'kimi-k2-instruct': { chars: 0, limit: 600000 }
         },
         gemini: {
-            'gemma-4-26b-a4b-it': { chars: 0 },
-        },
+            'gemma-4-26b-a4b-it': { chars: 0 }
+        }
     };
     limits.data.push(newEntry);
     setLimits(limits);
@@ -311,7 +311,7 @@ function incrementLimitCount(model) {
         todayEntry = {
             date: today,
             flash: { count: 0 },
-            flashLite: { count: 0 },
+            flashLite: { count: 0 }
         };
         limits.data.push(todayEntry);
     } else {
@@ -337,7 +337,7 @@ function incrementCharUsage(provider, model, charCount) {
     const today = getTodayDateString();
     const todayEntry = limits.data.find(entry => entry.date === today);
 
-    if (todayEntry[provider] && todayEntry[provider][model]) {
+    if(todayEntry[provider] && todayEntry[provider][model]) {
         todayEntry[provider][model].chars += charCount;
         setLimits(limits);
     }
@@ -401,7 +401,7 @@ function saveSession(sessionId, data) {
         customPrompt: data.customPrompt || existingSession?.customPrompt || null,
         // Conversation data
         conversationHistory: data.conversationHistory || existingSession?.conversationHistory || [],
-        screenAnalysisHistory: data.screenAnalysisHistory || existingSession?.screenAnalysisHistory || [],
+        screenAnalysisHistory: data.screenAnalysisHistory || existingSession?.screenAnalysisHistory || []
     };
     return writeJsonFile(sessionPath, sessionData);
 }
@@ -418,8 +418,7 @@ function getAllSessions() {
             return [];
         }
 
-        const files = fs
-            .readdirSync(historyDir)
+        const files = fs.readdirSync(historyDir)
             .filter(f => f.endsWith('.json'))
             .sort((a, b) => {
                 // Sort by timestamp descending (newest first)
@@ -428,24 +427,22 @@ function getAllSessions() {
                 return tsB - tsA;
             });
 
-        return files
-            .map(file => {
-                const sessionId = file.replace('.json', '');
-                const data = readJsonFile(path.join(historyDir, file), null);
-                if (data) {
-                    return {
-                        sessionId,
-                        createdAt: data.createdAt,
-                        lastUpdated: data.lastUpdated,
-                        messageCount: data.conversationHistory?.length || 0,
-                        screenAnalysisCount: data.screenAnalysisHistory?.length || 0,
-                        profile: data.profile || null,
-                        customPrompt: data.customPrompt || null,
-                    };
-                }
-                return null;
-            })
-            .filter(Boolean);
+        return files.map(file => {
+            const sessionId = file.replace('.json', '');
+            const data = readJsonFile(path.join(historyDir, file), null);
+            if (data) {
+                return {
+                    sessionId,
+                    createdAt: data.createdAt,
+                    lastUpdated: data.lastUpdated,
+                    messageCount: data.conversationHistory?.length || 0,
+                    screenAnalysisCount: data.screenAnalysisHistory?.length || 0,
+                    profile: data.profile || null,
+                    customPrompt: data.customPrompt || null
+                };
+            }
+            return null;
+        }).filter(Boolean);
     } catch (error) {
         console.error('Error reading sessions:', error.message);
         return [];
@@ -532,5 +529,5 @@ module.exports = {
     deleteAllSessions,
 
     // Clear all
-    clearAllData,
+    clearAllData
 };

--- a/src/storage.js
+++ b/src/storage.js
@@ -8,12 +8,12 @@ const CONFIG_VERSION = 1;
 const DEFAULT_CONFIG = {
     configVersion: CONFIG_VERSION,
     onboarded: false,
-    layout: 'normal'
+    layout: 'normal',
 };
 
 const DEFAULT_CREDENTIALS = {
     apiKey: '',
-    groqApiKey: ''
+    groqApiKey: '',
 };
 
 const DEFAULT_PREFERENCES = {
@@ -25,6 +25,7 @@ const DEFAULT_PREFERENCES = {
     selectedImageQuality: 'medium',
     advancedMode: false,
     audioMode: 'speaker_only',
+    captureDisplayId: '',
     fontSize: 'medium',
     backgroundTransparency: 0.8,
     googleSearchEnabled: false,
@@ -36,7 +37,7 @@ const DEFAULT_PREFERENCES = {
 const DEFAULT_KEYBINDS = null; // null means use system defaults
 
 const DEFAULT_LIMITS = {
-    data: [] // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-4-26b-a4b-it': { chars } } }
+    data: [], // Array of { date: 'YYYY-MM-DD', flash: { count }, flashLite: { count }, groq: { 'qwen3-32b': { chars, limit }, 'gpt-oss-120b': { chars, limit }, 'gpt-oss-20b': { chars, limit } }, gemini: { 'gemma-4-26b-a4b-it': { chars } } }
 };
 
 // Get the config directory path based on OS
@@ -258,17 +259,17 @@ function getTodayLimits() {
 
     if (todayEntry) {
         // ensure new fields exist
-        if(!todayEntry.groq) {
+        if (!todayEntry.groq) {
             todayEntry.groq = {
                 'qwen3-32b': { chars: 0, limit: 1500000 },
                 'gpt-oss-120b': { chars: 0, limit: 600000 },
                 'gpt-oss-20b': { chars: 0, limit: 600000 },
-                'kimi-k2-instruct': { chars: 0, limit: 600000 }
+                'kimi-k2-instruct': { chars: 0, limit: 600000 },
             };
         }
-        if(!todayEntry.gemini) {
+        if (!todayEntry.gemini) {
             todayEntry.gemini = {
-                'gemma-4-26b-a4b-it': { chars: 0 }
+                'gemma-4-26b-a4b-it': { chars: 0 },
             };
         }
         setLimits(limits);
@@ -285,11 +286,11 @@ function getTodayLimits() {
             'qwen3-32b': { chars: 0, limit: 1500000 },
             'gpt-oss-120b': { chars: 0, limit: 600000 },
             'gpt-oss-20b': { chars: 0, limit: 600000 },
-            'kimi-k2-instruct': { chars: 0, limit: 600000 }
+            'kimi-k2-instruct': { chars: 0, limit: 600000 },
         },
         gemini: {
-            'gemma-4-26b-a4b-it': { chars: 0 }
-        }
+            'gemma-4-26b-a4b-it': { chars: 0 },
+        },
     };
     limits.data.push(newEntry);
     setLimits(limits);
@@ -310,7 +311,7 @@ function incrementLimitCount(model) {
         todayEntry = {
             date: today,
             flash: { count: 0 },
-            flashLite: { count: 0 }
+            flashLite: { count: 0 },
         };
         limits.data.push(todayEntry);
     } else {
@@ -336,7 +337,7 @@ function incrementCharUsage(provider, model, charCount) {
     const today = getTodayDateString();
     const todayEntry = limits.data.find(entry => entry.date === today);
 
-    if(todayEntry[provider] && todayEntry[provider][model]) {
+    if (todayEntry[provider] && todayEntry[provider][model]) {
         todayEntry[provider][model].chars += charCount;
         setLimits(limits);
     }
@@ -400,7 +401,7 @@ function saveSession(sessionId, data) {
         customPrompt: data.customPrompt || existingSession?.customPrompt || null,
         // Conversation data
         conversationHistory: data.conversationHistory || existingSession?.conversationHistory || [],
-        screenAnalysisHistory: data.screenAnalysisHistory || existingSession?.screenAnalysisHistory || []
+        screenAnalysisHistory: data.screenAnalysisHistory || existingSession?.screenAnalysisHistory || [],
     };
     return writeJsonFile(sessionPath, sessionData);
 }
@@ -417,7 +418,8 @@ function getAllSessions() {
             return [];
         }
 
-        const files = fs.readdirSync(historyDir)
+        const files = fs
+            .readdirSync(historyDir)
             .filter(f => f.endsWith('.json'))
             .sort((a, b) => {
                 // Sort by timestamp descending (newest first)
@@ -426,22 +428,24 @@ function getAllSessions() {
                 return tsB - tsA;
             });
 
-        return files.map(file => {
-            const sessionId = file.replace('.json', '');
-            const data = readJsonFile(path.join(historyDir, file), null);
-            if (data) {
-                return {
-                    sessionId,
-                    createdAt: data.createdAt,
-                    lastUpdated: data.lastUpdated,
-                    messageCount: data.conversationHistory?.length || 0,
-                    screenAnalysisCount: data.screenAnalysisHistory?.length || 0,
-                    profile: data.profile || null,
-                    customPrompt: data.customPrompt || null
-                };
-            }
-            return null;
-        }).filter(Boolean);
+        return files
+            .map(file => {
+                const sessionId = file.replace('.json', '');
+                const data = readJsonFile(path.join(historyDir, file), null);
+                if (data) {
+                    return {
+                        sessionId,
+                        createdAt: data.createdAt,
+                        lastUpdated: data.lastUpdated,
+                        messageCount: data.conversationHistory?.length || 0,
+                        screenAnalysisCount: data.screenAnalysisHistory?.length || 0,
+                        profile: data.profile || null,
+                        customPrompt: data.customPrompt || null,
+                    };
+                }
+                return null;
+            })
+            .filter(Boolean);
     } catch (error) {
         console.error('Error reading sessions:', error.message);
         return [];
@@ -528,5 +532,5 @@ module.exports = {
     deleteAllSessions,
 
     // Clear all
-    clearAllData
+    clearAllData,
 };

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -106,7 +106,7 @@ const storage = {
     async getTodayLimits() {
         const result = await ipcRenderer.invoke('storage:get-today-limits');
         return result.success ? result.data : { flash: { count: 0 }, flashLite: { count: 0 } };
-    }
+    },
 };
 
 // Cache for preferences to avoid async calls in hot paths
@@ -115,6 +115,11 @@ let preferencesCache = null;
 async function loadPreferencesCache() {
     preferencesCache = await storage.getPreferences();
     return preferencesCache;
+}
+
+async function getCaptureDisplays() {
+    const result = await ipcRenderer.invoke('get-capture-displays');
+    return result.success ? result.data : [];
 }
 
 // Initialize preferences cache
@@ -741,7 +746,7 @@ ipcRenderer.on('save-session-context', async (event, data) => {
     try {
         await storage.saveSession(data.sessionId, {
             profile: data.profile,
-            customPrompt: data.customPrompt
+            customPrompt: data.customPrompt,
         });
         console.log('Session context saved:', data.sessionId, 'profile:', data.profile);
     } catch (error) {
@@ -755,7 +760,7 @@ ipcRenderer.on('save-screen-analysis', async (event, data) => {
         await storage.saveSession(data.sessionId, {
             screenAnalysisHistory: data.fullHistory,
             profile: data.profile,
-            customPrompt: data.customPrompt
+            customPrompt: data.customPrompt,
         });
         console.log('Screen analysis saved:', data.sessionId);
     } catch (error) {
@@ -790,75 +795,129 @@ const theme = {
     themes: {
         dark: {
             background: '#101010',
-            text: '#e0e0e0', textSecondary: '#a0a0a0', textMuted: '#6b6b6b',
-            border: '#2a2a2a', accent: '#ffffff',
-            btnPrimaryBg: '#ffffff', btnPrimaryText: '#000000', btnPrimaryHover: '#e0e0e0',
-            tooltipBg: '#1a1a1a', tooltipText: '#ffffff',
-            keyBg: 'rgba(255,255,255,0.1)'
+            text: '#e0e0e0',
+            textSecondary: '#a0a0a0',
+            textMuted: '#6b6b6b',
+            border: '#2a2a2a',
+            accent: '#ffffff',
+            btnPrimaryBg: '#ffffff',
+            btnPrimaryText: '#000000',
+            btnPrimaryHover: '#e0e0e0',
+            tooltipBg: '#1a1a1a',
+            tooltipText: '#ffffff',
+            keyBg: 'rgba(255,255,255,0.1)',
         },
         light: {
             background: '#ffffff',
-            text: '#1a1a1a', textSecondary: '#555555', textMuted: '#888888',
-            border: '#e0e0e0', accent: '#000000',
-            btnPrimaryBg: '#1a1a1a', btnPrimaryText: '#ffffff', btnPrimaryHover: '#333333',
-            tooltipBg: '#1a1a1a', tooltipText: '#ffffff',
-            keyBg: 'rgba(0,0,0,0.1)'
+            text: '#1a1a1a',
+            textSecondary: '#555555',
+            textMuted: '#888888',
+            border: '#e0e0e0',
+            accent: '#000000',
+            btnPrimaryBg: '#1a1a1a',
+            btnPrimaryText: '#ffffff',
+            btnPrimaryHover: '#333333',
+            tooltipBg: '#1a1a1a',
+            tooltipText: '#ffffff',
+            keyBg: 'rgba(0,0,0,0.1)',
         },
         midnight: {
             background: '#0d1117',
-            text: '#c9d1d9', textSecondary: '#8b949e', textMuted: '#6e7681',
-            border: '#30363d', accent: '#58a6ff',
-            btnPrimaryBg: '#58a6ff', btnPrimaryText: '#0d1117', btnPrimaryHover: '#79b8ff',
-            tooltipBg: '#161b22', tooltipText: '#c9d1d9',
-            keyBg: 'rgba(88,166,255,0.15)'
+            text: '#c9d1d9',
+            textSecondary: '#8b949e',
+            textMuted: '#6e7681',
+            border: '#30363d',
+            accent: '#58a6ff',
+            btnPrimaryBg: '#58a6ff',
+            btnPrimaryText: '#0d1117',
+            btnPrimaryHover: '#79b8ff',
+            tooltipBg: '#161b22',
+            tooltipText: '#c9d1d9',
+            keyBg: 'rgba(88,166,255,0.15)',
         },
         sepia: {
             background: '#f4ecd8',
-            text: '#5c4b37', textSecondary: '#7a6a56', textMuted: '#998875',
-            border: '#d4c8b0', accent: '#8b4513',
-            btnPrimaryBg: '#5c4b37', btnPrimaryText: '#f4ecd8', btnPrimaryHover: '#7a6a56',
-            tooltipBg: '#5c4b37', tooltipText: '#f4ecd8',
-            keyBg: 'rgba(92,75,55,0.15)'
+            text: '#5c4b37',
+            textSecondary: '#7a6a56',
+            textMuted: '#998875',
+            border: '#d4c8b0',
+            accent: '#8b4513',
+            btnPrimaryBg: '#5c4b37',
+            btnPrimaryText: '#f4ecd8',
+            btnPrimaryHover: '#7a6a56',
+            tooltipBg: '#5c4b37',
+            tooltipText: '#f4ecd8',
+            keyBg: 'rgba(92,75,55,0.15)',
         },
         catppuccin: {
             background: '#1e1e2e',
-            text: '#cdd6f4', textSecondary: '#a6adc8', textMuted: '#585b70',
-            border: '#313244', accent: '#cba6f7',
-            btnPrimaryBg: '#cba6f7', btnPrimaryText: '#1e1e2e', btnPrimaryHover: '#b4befe',
-            tooltipBg: '#313244', tooltipText: '#cdd6f4',
-            keyBg: 'rgba(203,166,247,0.12)'
+            text: '#cdd6f4',
+            textSecondary: '#a6adc8',
+            textMuted: '#585b70',
+            border: '#313244',
+            accent: '#cba6f7',
+            btnPrimaryBg: '#cba6f7',
+            btnPrimaryText: '#1e1e2e',
+            btnPrimaryHover: '#b4befe',
+            tooltipBg: '#313244',
+            tooltipText: '#cdd6f4',
+            keyBg: 'rgba(203,166,247,0.12)',
         },
         gruvbox: {
             background: '#1d2021',
-            text: '#ebdbb2', textSecondary: '#a89984', textMuted: '#665c54',
-            border: '#3c3836', accent: '#fe8019',
-            btnPrimaryBg: '#fe8019', btnPrimaryText: '#1d2021', btnPrimaryHover: '#fabd2f',
-            tooltipBg: '#3c3836', tooltipText: '#ebdbb2',
-            keyBg: 'rgba(254,128,25,0.12)'
+            text: '#ebdbb2',
+            textSecondary: '#a89984',
+            textMuted: '#665c54',
+            border: '#3c3836',
+            accent: '#fe8019',
+            btnPrimaryBg: '#fe8019',
+            btnPrimaryText: '#1d2021',
+            btnPrimaryHover: '#fabd2f',
+            tooltipBg: '#3c3836',
+            tooltipText: '#ebdbb2',
+            keyBg: 'rgba(254,128,25,0.12)',
         },
         rosepine: {
             background: '#191724',
-            text: '#e0def4', textSecondary: '#908caa', textMuted: '#6e6a86',
-            border: '#26233a', accent: '#ebbcba',
-            btnPrimaryBg: '#ebbcba', btnPrimaryText: '#191724', btnPrimaryHover: '#f6c177',
-            tooltipBg: '#26233a', tooltipText: '#e0def4',
-            keyBg: 'rgba(235,188,186,0.12)'
+            text: '#e0def4',
+            textSecondary: '#908caa',
+            textMuted: '#6e6a86',
+            border: '#26233a',
+            accent: '#ebbcba',
+            btnPrimaryBg: '#ebbcba',
+            btnPrimaryText: '#191724',
+            btnPrimaryHover: '#f6c177',
+            tooltipBg: '#26233a',
+            tooltipText: '#e0def4',
+            keyBg: 'rgba(235,188,186,0.12)',
         },
         solarized: {
             background: '#002b36',
-            text: '#93a1a1', textSecondary: '#839496', textMuted: '#586e75',
-            border: '#073642', accent: '#2aa198',
-            btnPrimaryBg: '#2aa198', btnPrimaryText: '#002b36', btnPrimaryHover: '#268bd2',
-            tooltipBg: '#073642', tooltipText: '#93a1a1',
-            keyBg: 'rgba(42,161,152,0.12)'
+            text: '#93a1a1',
+            textSecondary: '#839496',
+            textMuted: '#586e75',
+            border: '#073642',
+            accent: '#2aa198',
+            btnPrimaryBg: '#2aa198',
+            btnPrimaryText: '#002b36',
+            btnPrimaryHover: '#268bd2',
+            tooltipBg: '#073642',
+            tooltipText: '#93a1a1',
+            keyBg: 'rgba(42,161,152,0.12)',
         },
         tokyonight: {
             background: '#1a1b26',
-            text: '#c0caf5', textSecondary: '#9aa5ce', textMuted: '#565f89',
-            border: '#292e42', accent: '#7aa2f7',
-            btnPrimaryBg: '#7aa2f7', btnPrimaryText: '#1a1b26', btnPrimaryHover: '#bb9af7',
-            tooltipBg: '#292e42', tooltipText: '#c0caf5',
-            keyBg: 'rgba(122,162,247,0.12)'
+            text: '#c0caf5',
+            textSecondary: '#9aa5ce',
+            textMuted: '#565f89',
+            border: '#292e42',
+            accent: '#7aa2f7',
+            btnPrimaryBg: '#7aa2f7',
+            btnPrimaryText: '#1a1b26',
+            btnPrimaryHover: '#bb9af7',
+            tooltipBg: '#292e42',
+            tooltipText: '#c0caf5',
+            keyBg: 'rgba(122,162,247,0.12)',
         },
     },
 
@@ -878,29 +937,31 @@ const theme = {
             gruvbox: 'Gruvbox Dark',
             rosepine: 'Ros\u00e9 Pine',
             solarized: 'Solarized Dark',
-            tokyonight: 'Tokyo Night'
+            tokyonight: 'Tokyo Night',
         };
         return Object.keys(this.themes).map(key => ({
             value: key,
             name: names[key] || key,
-            colors: this.themes[key]
+            colors: this.themes[key],
         }));
     },
 
     hexToRgb(hex) {
         const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-        return result ? {
-            r: parseInt(result[1], 16),
-            g: parseInt(result[2], 16),
-            b: parseInt(result[3], 16)
-        } : { r: 30, g: 30, b: 30 };
+        return result
+            ? {
+                  r: parseInt(result[1], 16),
+                  g: parseInt(result[2], 16),
+                  b: parseInt(result[3], 16),
+              }
+            : { r: 30, g: 30, b: 30 };
     },
 
     lightenColor(rgb, amount) {
         return {
             r: Math.min(255, rgb.r + amount),
             g: Math.min(255, rgb.g + amount),
-            b: Math.min(255, rgb.b + amount)
+            b: Math.min(255, rgb.b + amount),
         };
     },
 
@@ -908,7 +969,7 @@ const theme = {
         return {
             r: Math.max(0, rgb.r - amount),
             g: Math.max(0, rgb.g - amount),
-            b: Math.max(0, rgb.b - amount)
+            b: Math.max(0, rgb.b - amount),
         };
     },
 
@@ -1004,7 +1065,7 @@ const theme = {
     async save(themeName) {
         await storage.updatePreference('theme', themeName);
         this.apply(themeName);
-    }
+    },
 };
 
 // Consolidated cheatingDaddy object - all functions in one place
@@ -1029,6 +1090,7 @@ const cheatingDaddy = {
     initializeGemini,
     initializeCloud,
     initializeLocal,
+    getCaptureDisplays,
     startCapture,
     stopCapture,
     sendTextMessage,

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -106,7 +106,7 @@ const storage = {
     async getTodayLimits() {
         const result = await ipcRenderer.invoke('storage:get-today-limits');
         return result.success ? result.data : { flash: { count: 0 }, flashLite: { count: 0 } };
-    },
+    }
 };
 
 // Cache for preferences to avoid async calls in hot paths
@@ -119,7 +119,7 @@ async function loadPreferencesCache() {
 
 async function getCaptureDisplays() {
     const result = await ipcRenderer.invoke('get-capture-displays');
-    return result.success ? result.data : [];
+    return result.success && Array.isArray(result.data) ? result.data : [];
 }
 
 // Initialize preferences cache
@@ -746,7 +746,7 @@ ipcRenderer.on('save-session-context', async (event, data) => {
     try {
         await storage.saveSession(data.sessionId, {
             profile: data.profile,
-            customPrompt: data.customPrompt,
+            customPrompt: data.customPrompt
         });
         console.log('Session context saved:', data.sessionId, 'profile:', data.profile);
     } catch (error) {
@@ -760,7 +760,7 @@ ipcRenderer.on('save-screen-analysis', async (event, data) => {
         await storage.saveSession(data.sessionId, {
             screenAnalysisHistory: data.fullHistory,
             profile: data.profile,
-            customPrompt: data.customPrompt,
+            customPrompt: data.customPrompt
         });
         console.log('Screen analysis saved:', data.sessionId);
     } catch (error) {
@@ -795,129 +795,75 @@ const theme = {
     themes: {
         dark: {
             background: '#101010',
-            text: '#e0e0e0',
-            textSecondary: '#a0a0a0',
-            textMuted: '#6b6b6b',
-            border: '#2a2a2a',
-            accent: '#ffffff',
-            btnPrimaryBg: '#ffffff',
-            btnPrimaryText: '#000000',
-            btnPrimaryHover: '#e0e0e0',
-            tooltipBg: '#1a1a1a',
-            tooltipText: '#ffffff',
-            keyBg: 'rgba(255,255,255,0.1)',
+            text: '#e0e0e0', textSecondary: '#a0a0a0', textMuted: '#6b6b6b',
+            border: '#2a2a2a', accent: '#ffffff',
+            btnPrimaryBg: '#ffffff', btnPrimaryText: '#000000', btnPrimaryHover: '#e0e0e0',
+            tooltipBg: '#1a1a1a', tooltipText: '#ffffff',
+            keyBg: 'rgba(255,255,255,0.1)'
         },
         light: {
             background: '#ffffff',
-            text: '#1a1a1a',
-            textSecondary: '#555555',
-            textMuted: '#888888',
-            border: '#e0e0e0',
-            accent: '#000000',
-            btnPrimaryBg: '#1a1a1a',
-            btnPrimaryText: '#ffffff',
-            btnPrimaryHover: '#333333',
-            tooltipBg: '#1a1a1a',
-            tooltipText: '#ffffff',
-            keyBg: 'rgba(0,0,0,0.1)',
+            text: '#1a1a1a', textSecondary: '#555555', textMuted: '#888888',
+            border: '#e0e0e0', accent: '#000000',
+            btnPrimaryBg: '#1a1a1a', btnPrimaryText: '#ffffff', btnPrimaryHover: '#333333',
+            tooltipBg: '#1a1a1a', tooltipText: '#ffffff',
+            keyBg: 'rgba(0,0,0,0.1)'
         },
         midnight: {
             background: '#0d1117',
-            text: '#c9d1d9',
-            textSecondary: '#8b949e',
-            textMuted: '#6e7681',
-            border: '#30363d',
-            accent: '#58a6ff',
-            btnPrimaryBg: '#58a6ff',
-            btnPrimaryText: '#0d1117',
-            btnPrimaryHover: '#79b8ff',
-            tooltipBg: '#161b22',
-            tooltipText: '#c9d1d9',
-            keyBg: 'rgba(88,166,255,0.15)',
+            text: '#c9d1d9', textSecondary: '#8b949e', textMuted: '#6e7681',
+            border: '#30363d', accent: '#58a6ff',
+            btnPrimaryBg: '#58a6ff', btnPrimaryText: '#0d1117', btnPrimaryHover: '#79b8ff',
+            tooltipBg: '#161b22', tooltipText: '#c9d1d9',
+            keyBg: 'rgba(88,166,255,0.15)'
         },
         sepia: {
             background: '#f4ecd8',
-            text: '#5c4b37',
-            textSecondary: '#7a6a56',
-            textMuted: '#998875',
-            border: '#d4c8b0',
-            accent: '#8b4513',
-            btnPrimaryBg: '#5c4b37',
-            btnPrimaryText: '#f4ecd8',
-            btnPrimaryHover: '#7a6a56',
-            tooltipBg: '#5c4b37',
-            tooltipText: '#f4ecd8',
-            keyBg: 'rgba(92,75,55,0.15)',
+            text: '#5c4b37', textSecondary: '#7a6a56', textMuted: '#998875',
+            border: '#d4c8b0', accent: '#8b4513',
+            btnPrimaryBg: '#5c4b37', btnPrimaryText: '#f4ecd8', btnPrimaryHover: '#7a6a56',
+            tooltipBg: '#5c4b37', tooltipText: '#f4ecd8',
+            keyBg: 'rgba(92,75,55,0.15)'
         },
         catppuccin: {
             background: '#1e1e2e',
-            text: '#cdd6f4',
-            textSecondary: '#a6adc8',
-            textMuted: '#585b70',
-            border: '#313244',
-            accent: '#cba6f7',
-            btnPrimaryBg: '#cba6f7',
-            btnPrimaryText: '#1e1e2e',
-            btnPrimaryHover: '#b4befe',
-            tooltipBg: '#313244',
-            tooltipText: '#cdd6f4',
-            keyBg: 'rgba(203,166,247,0.12)',
+            text: '#cdd6f4', textSecondary: '#a6adc8', textMuted: '#585b70',
+            border: '#313244', accent: '#cba6f7',
+            btnPrimaryBg: '#cba6f7', btnPrimaryText: '#1e1e2e', btnPrimaryHover: '#b4befe',
+            tooltipBg: '#313244', tooltipText: '#cdd6f4',
+            keyBg: 'rgba(203,166,247,0.12)'
         },
         gruvbox: {
             background: '#1d2021',
-            text: '#ebdbb2',
-            textSecondary: '#a89984',
-            textMuted: '#665c54',
-            border: '#3c3836',
-            accent: '#fe8019',
-            btnPrimaryBg: '#fe8019',
-            btnPrimaryText: '#1d2021',
-            btnPrimaryHover: '#fabd2f',
-            tooltipBg: '#3c3836',
-            tooltipText: '#ebdbb2',
-            keyBg: 'rgba(254,128,25,0.12)',
+            text: '#ebdbb2', textSecondary: '#a89984', textMuted: '#665c54',
+            border: '#3c3836', accent: '#fe8019',
+            btnPrimaryBg: '#fe8019', btnPrimaryText: '#1d2021', btnPrimaryHover: '#fabd2f',
+            tooltipBg: '#3c3836', tooltipText: '#ebdbb2',
+            keyBg: 'rgba(254,128,25,0.12)'
         },
         rosepine: {
             background: '#191724',
-            text: '#e0def4',
-            textSecondary: '#908caa',
-            textMuted: '#6e6a86',
-            border: '#26233a',
-            accent: '#ebbcba',
-            btnPrimaryBg: '#ebbcba',
-            btnPrimaryText: '#191724',
-            btnPrimaryHover: '#f6c177',
-            tooltipBg: '#26233a',
-            tooltipText: '#e0def4',
-            keyBg: 'rgba(235,188,186,0.12)',
+            text: '#e0def4', textSecondary: '#908caa', textMuted: '#6e6a86',
+            border: '#26233a', accent: '#ebbcba',
+            btnPrimaryBg: '#ebbcba', btnPrimaryText: '#191724', btnPrimaryHover: '#f6c177',
+            tooltipBg: '#26233a', tooltipText: '#e0def4',
+            keyBg: 'rgba(235,188,186,0.12)'
         },
         solarized: {
             background: '#002b36',
-            text: '#93a1a1',
-            textSecondary: '#839496',
-            textMuted: '#586e75',
-            border: '#073642',
-            accent: '#2aa198',
-            btnPrimaryBg: '#2aa198',
-            btnPrimaryText: '#002b36',
-            btnPrimaryHover: '#268bd2',
-            tooltipBg: '#073642',
-            tooltipText: '#93a1a1',
-            keyBg: 'rgba(42,161,152,0.12)',
+            text: '#93a1a1', textSecondary: '#839496', textMuted: '#586e75',
+            border: '#073642', accent: '#2aa198',
+            btnPrimaryBg: '#2aa198', btnPrimaryText: '#002b36', btnPrimaryHover: '#268bd2',
+            tooltipBg: '#073642', tooltipText: '#93a1a1',
+            keyBg: 'rgba(42,161,152,0.12)'
         },
         tokyonight: {
             background: '#1a1b26',
-            text: '#c0caf5',
-            textSecondary: '#9aa5ce',
-            textMuted: '#565f89',
-            border: '#292e42',
-            accent: '#7aa2f7',
-            btnPrimaryBg: '#7aa2f7',
-            btnPrimaryText: '#1a1b26',
-            btnPrimaryHover: '#bb9af7',
-            tooltipBg: '#292e42',
-            tooltipText: '#c0caf5',
-            keyBg: 'rgba(122,162,247,0.12)',
+            text: '#c0caf5', textSecondary: '#9aa5ce', textMuted: '#565f89',
+            border: '#292e42', accent: '#7aa2f7',
+            btnPrimaryBg: '#7aa2f7', btnPrimaryText: '#1a1b26', btnPrimaryHover: '#bb9af7',
+            tooltipBg: '#292e42', tooltipText: '#c0caf5',
+            keyBg: 'rgba(122,162,247,0.12)'
         },
     },
 
@@ -937,31 +883,29 @@ const theme = {
             gruvbox: 'Gruvbox Dark',
             rosepine: 'Ros\u00e9 Pine',
             solarized: 'Solarized Dark',
-            tokyonight: 'Tokyo Night',
+            tokyonight: 'Tokyo Night'
         };
         return Object.keys(this.themes).map(key => ({
             value: key,
             name: names[key] || key,
-            colors: this.themes[key],
+            colors: this.themes[key]
         }));
     },
 
     hexToRgb(hex) {
         const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-        return result
-            ? {
-                  r: parseInt(result[1], 16),
-                  g: parseInt(result[2], 16),
-                  b: parseInt(result[3], 16),
-              }
-            : { r: 30, g: 30, b: 30 };
+        return result ? {
+            r: parseInt(result[1], 16),
+            g: parseInt(result[2], 16),
+            b: parseInt(result[3], 16)
+        } : { r: 30, g: 30, b: 30 };
     },
 
     lightenColor(rgb, amount) {
         return {
             r: Math.min(255, rgb.r + amount),
             g: Math.min(255, rgb.g + amount),
-            b: Math.min(255, rgb.b + amount),
+            b: Math.min(255, rgb.b + amount)
         };
     },
 
@@ -969,7 +913,7 @@ const theme = {
         return {
             r: Math.max(0, rgb.r - amount),
             g: Math.max(0, rgb.g - amount),
-            b: Math.max(0, rgb.b - amount),
+            b: Math.max(0, rgb.b - amount)
         };
     },
 
@@ -1065,7 +1009,7 @@ const theme = {
     async save(themeName) {
         await storage.updatePreference('theme', themeName);
         this.apply(themeName);
-    },
+    }
 };
 
 // Consolidated cheatingDaddy object - all functions in one place

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -356,6 +356,7 @@ function setupWindowIpcHandlers(mainWindow, sendToRenderer, geminiSessionRef) {
             return { success: false, error: error.message };
         }
     });
+
 }
 
 module.exports = {

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -7,6 +7,18 @@ let mouseEventsIgnored = false;
 const DEFAULT_MAIN_WINDOW_SIZE = { width: 1100, height: 800 };
 const MIN_WINDOW_SIZE = { width: 700, height: 320 };
 
+function selectCaptureSource(sources, preferredDisplayId, primaryDisplayId) {
+    const preferredId = String(preferredDisplayId || '');
+    const primaryId = String(primaryDisplayId || '');
+
+    return (
+        sources.find(source => preferredId && String(source.display_id) === preferredId) ||
+        sources.find(source => primaryId && String(source.display_id) === primaryId) ||
+        sources[0] ||
+        null
+    );
+}
+
 function createWindow(sendToRenderer, geminiSessionRef) {
     let windowWidth = DEFAULT_MAIN_WINDOW_SIZE.width;
     let windowHeight = DEFAULT_MAIN_WINDOW_SIZE.height;
@@ -33,14 +45,27 @@ function createWindow(sendToRenderer, geminiSessionRef) {
     });
 
     const { session, desktopCapturer } = require('electron');
-    session.defaultSession.setDisplayMediaRequestHandler(
-        (request, callback) => {
-            desktopCapturer.getSources({ types: ['screen'] }).then(sources => {
-                callback({ video: sources[0], audio: 'loopback' });
+    session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
+        desktopCapturer
+            .getSources({ types: ['screen'] })
+            .then(sources => {
+                const preferences = storage.getPreferences();
+                const primaryDisplayId = screen.getPrimaryDisplay().id;
+                const source = selectCaptureSource(sources, preferences.captureDisplayId, primaryDisplayId);
+
+                if (!source) {
+                    console.error('No display capture sources are available');
+                    callback({});
+                    return;
+                }
+
+                callback({ video: source, audio: 'loopback' });
+            })
+            .catch(error => {
+                console.error('Failed to select a display capture source:', error);
+                callback({});
             });
-        },
-        { useSystemPicker: true }
-    );
+    });
 
     mainWindow.setContentProtection(true);
     mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
@@ -331,12 +356,12 @@ function setupWindowIpcHandlers(mainWindow, sendToRenderer, geminiSessionRef) {
             return { success: false, error: error.message };
         }
     });
-
 }
 
 module.exports = {
     createWindow,
     getDefaultKeybinds,
+    selectCaptureSource,
     updateGlobalShortcuts,
     setupWindowIpcHandlers,
 };


### PR DESCRIPTION
## Summary

- expose connected displays in Settings and persist the selected display ID
- isolate display enumeration failures so preferences and keybinds still load
- match Electron desktop capture sources by `display_id`
- fall back to the current primary display when the saved display is disconnected
- handle empty or failed source enumeration without an unhandled rejection

## Verification

- `node --check src/utils/window.js src/index.js src/utils/renderer.js src/storage.js`
- capture source selection assertions for preferred, primary, first-source, and empty-source paths
- `npm run lint`
- `npm run package`
- `npm start`

Fixes #388