### PR TITLE
fix(security): encrypt stored API credentials

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,6 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const {
+    createCredentialEnvelope,
+    decryptCredentialEnvelope,
+    isCredentialEnvelope,
+    normalizeCredentials,
+    validateCredentialUpdate,
+} = require('./utils/credentialStore');
 
 const CONFIG_VERSION = 1;
 
@@ -94,13 +101,19 @@ function readJsonFile(filePath, defaultValue) {
 }
 
 // Helper to write JSON file safely
-function writeJsonFile(filePath, data) {
+function writeJsonFile(filePath, data, options = {}) {
     try {
         const dir = path.dirname(filePath);
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }
-        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+            encoding: 'utf8',
+            mode: options.mode,
+        });
+        if (options.mode !== undefined) {
+            fs.chmodSync(filePath, options.mode);
+        }
         return true;
     } catch (error) {
         console.error(`Error writing ${filePath}:`, error.message);
@@ -140,7 +153,7 @@ function resetConfigDir() {
 
     // Initialize with defaults
     writeJsonFile(getConfigPath(), DEFAULT_CONFIG);
-    writeJsonFile(getCredentialsPath(), DEFAULT_CREDENTIALS);
+    writeCredentialsFile(DEFAULT_CREDENTIALS);
     writeJsonFile(getPreferencesPath(), DEFAULT_PREFERENCES);
 
     console.log('Config directory initialized with defaults');
@@ -179,14 +192,48 @@ function updateConfig(key, value) {
 
 // ============ CREDENTIALS ============
 
+function getSafeStorage() {
+    return require('electron').safeStorage;
+}
+
+function writeCredentialsFile(credentials) {
+    const envelope = createCredentialEnvelope(credentials, getSafeStorage());
+    if (!writeJsonFile(getCredentialsPath(), envelope, { mode: 0o600 })) {
+        throw new Error('Failed to write credential store');
+    }
+    return true;
+}
+
 function getCredentials() {
-    return readJsonFile(getCredentialsPath(), DEFAULT_CREDENTIALS);
+    const credentialsPath = getCredentialsPath();
+    if (!fs.existsSync(credentialsPath)) {
+        writeCredentialsFile(DEFAULT_CREDENTIALS);
+        return { ...DEFAULT_CREDENTIALS };
+    }
+
+    const stored = readJsonFile(credentialsPath, null);
+    if (stored === null) {
+        throw new Error('Failed to read credential store');
+    }
+    if (isCredentialEnvelope(stored)) {
+        return decryptCredentialEnvelope(stored, getSafeStorage());
+    }
+
+    // Migrate legacy plaintext credentials after the first successful read.
+    const credentials = normalizeCredentials(stored);
+    try {
+        writeCredentialsFile(credentials);
+    } catch (error) {
+        console.warn('Could not migrate plaintext credentials to secure storage:', error.message);
+    }
+    return credentials;
 }
 
 function setCredentials(credentials) {
+    validateCredentialUpdate(credentials);
     const current = getCredentials();
-    const updated = { ...current, ...credentials };
-    return writeJsonFile(getCredentialsPath(), updated);
+    const updated = normalizeCredentials({ ...current, ...credentials });
+    return writeCredentialsFile(updated);
 }
 
 function getApiKey() {

--- a/src/storage.js
+++ b/src/storage.js
@@ -20,7 +20,9 @@ const DEFAULT_CONFIG = {
 
 const DEFAULT_CREDENTIALS = {
     apiKey: '',
-    groqApiKey: ''
+    groqApiKey: '',
+    cloudToken: '',
+    openaiKey: ''
 };
 
 const DEFAULT_PREFERENCES = {
@@ -213,10 +215,16 @@ function getCredentials() {
 
     const stored = readJsonFile(credentialsPath, null);
     if (stored === null) {
-        throw new Error('Failed to read credential store');
+        console.warn('Failed to read credential store, using empty credentials');
+        return { ...DEFAULT_CREDENTIALS };
     }
     if (isCredentialEnvelope(stored)) {
-        return decryptCredentialEnvelope(stored, getSafeStorage());
+        try {
+            return decryptCredentialEnvelope(stored, getSafeStorage());
+        } catch (error) {
+            console.warn('Failed to decrypt credential store, using empty credentials:', error.message);
+            return { ...DEFAULT_CREDENTIALS };
+        }
     }
 
     // Migrate legacy plaintext credentials after the first successful read.

--- a/src/utils/credentialStore.js
+++ b/src/utils/credentialStore.js
@@ -3,6 +3,8 @@ const CREDENTIAL_KEYS = Object.freeze(['apiKey', 'groqApiKey', 'cloudToken', 'op
 const DEFAULT_CREDENTIALS = Object.freeze({
     apiKey: '',
     groqApiKey: '',
+    cloudToken: '',
+    openaiKey: '',
 });
 
 function normalizeCredentials(credentials) {

--- a/src/utils/credentialStore.js
+++ b/src/utils/credentialStore.js
@@ -1,0 +1,98 @@
+const CREDENTIAL_STORE_VERSION = 1;
+const CREDENTIAL_KEYS = Object.freeze(['apiKey', 'groqApiKey', 'cloudToken', 'openaiKey']);
+const DEFAULT_CREDENTIALS = Object.freeze({
+    apiKey: '',
+    groqApiKey: '',
+});
+
+function normalizeCredentials(credentials) {
+    const normalized = { ...DEFAULT_CREDENTIALS };
+    if (!credentials || typeof credentials !== 'object' || Array.isArray(credentials)) {
+        return normalized;
+    }
+
+    for (const key of CREDENTIAL_KEYS) {
+        if (typeof credentials[key] === 'string') {
+            normalized[key] = credentials[key];
+        }
+    }
+    return normalized;
+}
+
+function validateCredentialUpdate(credentials) {
+    if (!credentials || typeof credentials !== 'object' || Array.isArray(credentials)) {
+        throw new TypeError('Credentials must be an object');
+    }
+
+    for (const [key, value] of Object.entries(credentials)) {
+        if (!CREDENTIAL_KEYS.includes(key) || typeof value !== 'string') {
+            throw new TypeError(`Invalid credential field: ${key}`);
+        }
+    }
+}
+
+function hasStoredSecrets(credentials) {
+    return Object.values(credentials).some(value => value.length > 0);
+}
+
+function isCredentialEnvelope(value) {
+    return Boolean(
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        Object.prototype.hasOwnProperty.call(value, 'version') &&
+        Object.prototype.hasOwnProperty.call(value, 'encryptedData')
+    );
+}
+
+function assertSecureStorage(safeStorage, platform) {
+    if (!safeStorage || typeof safeStorage.isEncryptionAvailable !== 'function' || !safeStorage.isEncryptionAvailable()) {
+        throw new Error('Secure credential storage is unavailable');
+    }
+
+    if (
+        platform === 'linux' &&
+        typeof safeStorage.getSelectedStorageBackend === 'function' &&
+        safeStorage.getSelectedStorageBackend() === 'basic_text'
+    ) {
+        throw new Error('A secure system keyring is required to store credentials');
+    }
+}
+
+function createCredentialEnvelope(credentials, safeStorage, platform = process.platform) {
+    const normalized = normalizeCredentials(credentials);
+    if (!hasStoredSecrets(normalized)) {
+        return { version: CREDENTIAL_STORE_VERSION, encryptedData: null };
+    }
+
+    assertSecureStorage(safeStorage, platform);
+    const encrypted = safeStorage.encryptString(JSON.stringify(normalized));
+    return {
+        version: CREDENTIAL_STORE_VERSION,
+        encryptedData: encrypted.toString('base64'),
+    };
+}
+
+function decryptCredentialEnvelope(envelope, safeStorage, platform = process.platform) {
+    if (!isCredentialEnvelope(envelope) || envelope.version !== CREDENTIAL_STORE_VERSION) {
+        throw new Error('Unsupported credential store format');
+    }
+    if (envelope.encryptedData === null) {
+        return { ...DEFAULT_CREDENTIALS };
+    }
+    if (typeof envelope.encryptedData !== 'string' || envelope.encryptedData.length === 0) {
+        throw new Error('Invalid encrypted credential data');
+    }
+
+    assertSecureStorage(safeStorage, platform);
+    const decrypted = safeStorage.decryptString(Buffer.from(envelope.encryptedData, 'base64'));
+    return normalizeCredentials(JSON.parse(decrypted));
+}
+
+module.exports = {
+    createCredentialEnvelope,
+    decryptCredentialEnvelope,
+    isCredentialEnvelope,
+    normalizeCredentials,
+    validateCredentialUpdate,
+};

--- a/test/credentialStore.test.js
+++ b/test/credentialStore.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    createCredentialEnvelope,
+    decryptCredentialEnvelope,
+    isCredentialEnvelope,
+    normalizeCredentials,
+    validateCredentialUpdate,
+} = require('../src/utils/credentialStore');
+
+function createFakeSafeStorage({ available = true, backend = 'keychain' } = {}) {
+    return {
+        isEncryptionAvailable: () => available,
+        getSelectedStorageBackend: () => backend,
+        encryptString: value => Buffer.from([...value].reverse().join('')),
+        decryptString: value => [...value.toString()].reverse().join(''),
+    };
+}
+
+test('round-trips all supported credentials without plaintext in the envelope', () => {
+    const safeStorage = createFakeSafeStorage();
+    const credentials = {
+        apiKey: 'gemini-secret',
+        groqApiKey: 'groq-secret',
+        cloudToken: 'cloud-secret',
+        openaiKey: 'openai-secret',
+    };
+
+    const envelope = createCredentialEnvelope(credentials, safeStorage, 'darwin');
+
+    assert.equal(isCredentialEnvelope(envelope), true);
+    assert.equal(JSON.stringify(envelope).includes('gemini-secret'), false);
+    assert.deepEqual(decryptCredentialEnvelope(envelope, safeStorage, 'darwin'), credentials);
+});
+
+test('stores empty credentials without requiring an encryption backend', () => {
+    const envelope = createCredentialEnvelope({ apiKey: '', groqApiKey: '' }, null, 'darwin');
+
+    assert.deepEqual(envelope, { version: 1, encryptedData: null });
+    assert.deepEqual(decryptCredentialEnvelope(envelope, null, 'darwin'), { apiKey: '', groqApiKey: '' });
+});
+
+test('rejects secrets when secure storage is unavailable or insecure', () => {
+    assert.throws(() => createCredentialEnvelope({ apiKey: 'secret' }, createFakeSafeStorage({ available: false }), 'win32'));
+    assert.throws(() => createCredentialEnvelope({ apiKey: 'secret' }, createFakeSafeStorage({ backend: 'basic_text' }), 'linux'));
+});
+
+test('validates updates and removes unsupported legacy fields', () => {
+    assert.throws(() => validateCredentialUpdate({ unexpected: 'secret' }), /Invalid credential field/);
+    assert.deepEqual(normalizeCredentials({ apiKey: 'secret', unexpected: 'ignored' }), { apiKey: 'secret', groqApiKey: '' });
+});

--- a/test/credentialStore.test.js
+++ b/test/credentialStore.test.js
@@ -37,7 +37,12 @@ test('stores empty credentials without requiring an encryption backend', () => {
     const envelope = createCredentialEnvelope({ apiKey: '', groqApiKey: '' }, null, 'darwin');
 
     assert.deepEqual(envelope, { version: 1, encryptedData: null });
-    assert.deepEqual(decryptCredentialEnvelope(envelope, null, 'darwin'), { apiKey: '', groqApiKey: '' });
+    assert.deepEqual(decryptCredentialEnvelope(envelope, null, 'darwin'), {
+        apiKey: '',
+        groqApiKey: '',
+        cloudToken: '',
+        openaiKey: '',
+    });
 });
 
 test('rejects secrets when secure storage is unavailable or insecure', () => {
@@ -47,5 +52,10 @@ test('rejects secrets when secure storage is unavailable or insecure', () => {
 
 test('validates updates and removes unsupported legacy fields', () => {
     assert.throws(() => validateCredentialUpdate({ unexpected: 'secret' }), /Invalid credential field/);
-    assert.deepEqual(normalizeCredentials({ apiKey: 'secret', unexpected: 'ignored' }), { apiKey: 'secret', groqApiKey: '' });
+    assert.deepEqual(normalizeCredentials({ apiKey: 'secret', unexpected: 'ignored' }), {
+        apiKey: 'secret',
+        groqApiKey: '',
+        cloudToken: '',
+        openaiKey: '',
+    });
 });


### PR DESCRIPTION
## Summary

- encrypt Gemini, Groq, cloud, and OpenAI credentials with Electron `safeStorage`
- use the macOS Keychain / Windows DPAPI-backed Electron implementation instead of storing plaintext JSON
- migrate existing plaintext credentials on first read
- return a complete empty credential shape when an old envelope cannot be read, allowing the user to replace unusable credentials
- reject new secret writes when encryption is unavailable, including the insecure Linux `basic_text` backend
- restrict the credential file to mode `0600` and validate IPC-supplied credential fields

The encrypted envelope contains no provider names or plaintext secrets. Empty credentials use a versioned empty envelope and do not require a keyring.

## Verification

- `node --test test/credentialStore.test.js` (4 passing tests)
- `node --check src/storage.js src/utils/credentialStore.js`
- `npm run lint`
- `npm run package`
- `npm start`
- verified legacy file migration to the versioned envelope and mode `0600` on macOS

Fixes #2