### PR TITLE
fix(local-ai): stabilize Whisper model loading

### DIFF
--- a/src/components/views/MainView.js
+++ b/src/components/views/MainView.js
@@ -498,6 +498,7 @@ export class MainView extends LitElement {
         _ollamaHost: { state: true },
         _ollamaModel: { state: true },
         _whisperModel: { state: true },
+        _whisperDevice: { state: true },
         _showLocalHelp: { state: true },
     };
 
@@ -521,6 +522,7 @@ export class MainView extends LitElement {
         this._ollamaHost = 'http://127.0.0.1:11434';
         this._ollamaModel = 'llama3.1';
         this._whisperModel = 'Xenova/whisper-small';
+        this._whisperDevice = 'cpu';
 
         this._animId = null;
         this._time = 0;
@@ -555,6 +557,7 @@ export class MainView extends LitElement {
             this._ollamaHost = prefs.ollamaHost || 'http://127.0.0.1:11434';
             this._ollamaModel = prefs.ollamaModel || 'llama3.1';
             this._whisperModel = prefs.whisperModel || 'Xenova/whisper-small';
+            this._whisperDevice = prefs.whisperDevice === 'dml' && cheatingDaddy.isWindows ? 'dml' : 'cpu';
 
             this.requestUpdate();
         } catch (e) {
@@ -743,6 +746,12 @@ export class MainView extends LitElement {
         this.requestUpdate();
     }
 
+    async _saveWhisperDevice(val) {
+        this._whisperDevice = val;
+        await cheatingDaddy.storage.updatePreference('whisperDevice', val);
+        this.requestUpdate();
+    }
+
     _handleProfileChange(e) {
         this.onProfileChange(e.target.value);
     }
@@ -900,6 +909,19 @@ export class MainView extends LitElement {
                 </select>
                 <div class="form-hint">${this.whisperDownloading ? 'Downloading model...' : 'Downloaded automatically on first use'}</div>
             </div>
+
+            ${cheatingDaddy.isWindows
+                ? html`
+                      <div class="form-group">
+                          <label class="form-label">Whisper Device</label>
+                          <select .value=${this._whisperDevice} @change=${e => this._saveWhisperDevice(e.target.value)}>
+                              <option value="cpu">CPU (stable, recommended)</option>
+                              <option value="dml">DirectML GPU (experimental)</option>
+                          </select>
+                          <div class="form-hint">DirectML can be faster but may be unstable on multi-GPU systems</div>
+                      </div>
+                  `
+                : ''}
 
             ${this._renderStartButton()}
             ${this._renderDivider()}

--- a/src/storage.js
+++ b/src/storage.js
@@ -31,6 +31,7 @@ const DEFAULT_PREFERENCES = {
     ollamaHost: 'http://127.0.0.1:11434',
     ollamaModel: 'llama3.1',
     whisperModel: 'Xenova/whisper-small',
+    whisperDevice: 'cpu',
 };
 
 const DEFAULT_KEYBINDS = null; // null means use system defaults

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -865,9 +865,9 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
         return false;
     });
 
-    ipcMain.handle('initialize-local', async (event, ollamaHost, ollamaModel, whisperModel, profile, customPrompt) => {
+    ipcMain.handle('initialize-local', async (event, ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice = 'cpu') => {
         currentProviderMode = 'local';
-        const success = await getLocalAi().initializeLocalSession(ollamaHost, ollamaModel, whisperModel, profile, customPrompt);
+        const success = await getLocalAi().initializeLocalSession(ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice);
         if (!success) {
             currentProviderMode = 'byok';
         }

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -866,8 +866,14 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
     });
 
     ipcMain.handle('initialize-local', async (event, ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice = 'cpu') => {
+        const requiredValues = [ollamaHost, ollamaModel, whisperModel, profile, customPrompt];
+        if (requiredValues.some(value => typeof value !== 'string') || [ollamaHost, ollamaModel, whisperModel, profile].some(value => !value.trim())) {
+            return false;
+        }
+        const sanitizedDevice = whisperDevice === 'dml' && process.platform === 'win32' ? 'dml' : 'cpu';
+
         currentProviderMode = 'local';
-        const success = await getLocalAi().initializeLocalSession(ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice);
+        const success = await getLocalAi().initializeLocalSession(ollamaHost, ollamaModel, whisperModel, profile, customPrompt, sanitizedDevice);
         if (!success) {
             currentProviderMode = 'byok';
         }

--- a/src/utils/localai.js
+++ b/src/utils/localai.js
@@ -123,7 +123,10 @@ async function loadWhisperPipeline(modelName, requestedDevice = 'cpu') {
         return whisperPipeline;
     }
     if (whisperLoadPromise) {
-        await whisperLoadPromise;
+        const loadedPipeline = await whisperLoadPromise;
+        if (!loadedPipeline) {
+            return null;
+        }
         return loadWhisperPipeline(modelName, device);
     }
 
@@ -139,6 +142,7 @@ async function loadWhisperPipeline(modelName, requestedDevice = 'cpu') {
                 }
             } catch (error) {
                 console.warn('[LocalAI] Failed to dispose the previous Whisper pipeline:', error.message);
+                throw error;
             }
             whisperPipeline = null;
             whisperPipelineModel = null;

--- a/src/utils/localai.js
+++ b/src/utils/localai.js
@@ -1,13 +1,18 @@
 const { Ollama } = require('ollama');
+const fs = require('fs');
+const path = require('path');
 const { getSystemPrompt } = require('./prompts');
 const { sendToRenderer, initializeNewSession, saveConversationTurn } = require('./gemini');
+const { getWhisperModelCachePath, loadWhisperPipelineWithRecovery, normalizeWhisperDevice } = require('./whisperRuntime');
 
 // ── State ──
 
 let ollamaClient = null;
 let ollamaModel = null;
 let whisperPipeline = null;
-let isWhisperLoading = false;
+let whisperPipelineModel = null;
+let whisperPipelineDevice = null;
+let whisperLoadPromise = null;
 let localConversationHistory = [];
 let currentSystemPrompt = null;
 let isLocalActive = false;
@@ -112,37 +117,70 @@ function processVAD(pcm16kBuffer) {
 
 // ── Whisper Transcription ──
 
-async function loadWhisperPipeline(modelName) {
-    if (whisperPipeline) return whisperPipeline;
-    if (isWhisperLoading) return null;
+async function loadWhisperPipeline(modelName, requestedDevice = 'cpu') {
+    const device = normalizeWhisperDevice(requestedDevice);
+    if (whisperPipeline && whisperPipelineModel === modelName && whisperPipelineDevice === device) {
+        return whisperPipeline;
+    }
+    if (whisperLoadPromise) {
+        await whisperLoadPromise;
+        return loadWhisperPipeline(modelName, device);
+    }
 
-    isWhisperLoading = true;
     console.log('[LocalAI] Loading Whisper model:', modelName);
     sendToRenderer('whisper-downloading', true);
     sendToRenderer('update-status', 'Loading Whisper model (first time may take a while)...');
 
-    try {
+    whisperLoadPromise = (async () => {
+        if (whisperPipeline) {
+            try {
+                if (typeof whisperPipeline.dispose === 'function') {
+                    await whisperPipeline.dispose();
+                }
+            } catch (error) {
+                console.warn('[LocalAI] Failed to dispose the previous Whisper pipeline:', error.message);
+            }
+            whisperPipeline = null;
+            whisperPipelineModel = null;
+            whisperPipelineDevice = null;
+        }
+
         // Dynamic import for ESM module
         const { pipeline, env } = await import('@huggingface/transformers');
         // Cache models outside the asar archive so ONNX runtime can load them
         const { app } = require('electron');
-        const path = require('path');
         env.cacheDir = path.join(app.getPath('userData'), 'whisper-models');
-        whisperPipeline = await pipeline('automatic-speech-recognition', modelName, {
-            dtype: 'q8',
-            device: 'auto',
-        });
+        const modelCachePath = getWhisperModelCachePath(env.cacheDir, modelName);
+        const createPipeline = () =>
+            pipeline('automatic-speech-recognition', modelName, {
+                dtype: 'q8',
+                device,
+            });
+
+        whisperPipeline = await loadWhisperPipelineWithRecovery(
+            createPipeline,
+            () => fs.promises.rm(modelCachePath, { recursive: true, force: true }),
+            () => {
+                console.warn('[LocalAI] Corrupt Whisper cache detected, clearing:', modelCachePath);
+                sendToRenderer('update-status', 'Whisper model cache was corrupt. Downloading a fresh copy...');
+            }
+        );
+        whisperPipelineModel = modelName;
+        whisperPipelineDevice = device;
         console.log('[LocalAI] Whisper model loaded successfully');
-        sendToRenderer('whisper-downloading', false);
-        isWhisperLoading = false;
         return whisperPipeline;
-    } catch (error) {
-        console.error('[LocalAI] Failed to load Whisper model:', error);
-        sendToRenderer('whisper-downloading', false);
-        sendToRenderer('update-status', 'Failed to load Whisper model: ' + error.message);
-        isWhisperLoading = false;
-        return null;
-    }
+    })()
+        .catch(error => {
+            console.error('[LocalAI] Failed to load Whisper model:', error);
+            sendToRenderer('update-status', 'Failed to load Whisper model: ' + error.message);
+            return null;
+        })
+        .finally(() => {
+            sendToRenderer('whisper-downloading', false);
+            whisperLoadPromise = null;
+        });
+
+    return whisperLoadPromise;
 }
 
 function pcm16ToFloat32(pcm16Buffer) {
@@ -266,8 +304,8 @@ async function sendToOllama(transcription) {
 
 // ── Public API ──
 
-async function initializeLocalSession(ollamaHost, model, whisperModel, profile, customPrompt) {
-    console.log('[LocalAI] Initializing local session:', { ollamaHost, model, whisperModel, profile });
+async function initializeLocalSession(ollamaHost, model, whisperModel, profile, customPrompt, whisperDevice = 'cpu') {
+    console.log('[LocalAI] Initializing local session:', { ollamaHost, model, whisperModel, whisperDevice, profile });
 
     sendToRenderer('session-initializing', true);
 
@@ -291,7 +329,7 @@ async function initializeLocalSession(ollamaHost, model, whisperModel, profile, 
         }
 
         // Load Whisper model
-        const pipeline = await loadWhisperPipeline(whisperModel);
+        const pipeline = await loadWhisperPipeline(whisperModel, whisperDevice);
         if (!pipeline) {
             sendToRenderer('session-initializing', false);
             return false;

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -159,7 +159,7 @@ async function initializeLocal(profile = 'interview') {
     const ollamaHost = prefs.ollamaHost || 'http://127.0.0.1:11434';
     const ollamaModel = prefs.ollamaModel || 'llama3.1';
     const whisperModel = prefs.whisperModel || 'Xenova/whisper-small';
-    const whisperDevice = prefs.whisperDevice || 'cpu';
+    const whisperDevice = prefs.whisperDevice === 'dml' && isWindows ? 'dml' : 'cpu';
     const customPrompt = prefs.customPrompt || '';
 
     const success = await ipcRenderer.invoke('initialize-local', ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice);

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -18,6 +18,7 @@ let currentImageQuality = 'medium'; // Store current image quality for manual sc
 
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
+const isWindows = process.platform === 'win32';
 
 // ============ STORAGE API ============
 // Wrapper for IPC-based storage access
@@ -158,9 +159,10 @@ async function initializeLocal(profile = 'interview') {
     const ollamaHost = prefs.ollamaHost || 'http://127.0.0.1:11434';
     const ollamaModel = prefs.ollamaModel || 'llama3.1';
     const whisperModel = prefs.whisperModel || 'Xenova/whisper-small';
+    const whisperDevice = prefs.whisperDevice || 'cpu';
     const customPrompt = prefs.customPrompt || '';
 
-    const success = await ipcRenderer.invoke('initialize-local', ollamaHost, ollamaModel, whisperModel, profile, customPrompt);
+    const success = await ipcRenderer.invoke('initialize-local', ollamaHost, ollamaModel, whisperModel, profile, customPrompt, whisperDevice);
     if (success) {
         cheatingDaddy.setStatus('Local AI Live');
         return true;
@@ -1046,6 +1048,7 @@ const cheatingDaddy = {
     // Platform detection
     isLinux: isLinux,
     isMacOS: isMacOS,
+    isWindows: isWindows,
 };
 
 // Make it globally available

--- a/src/utils/whisperRuntime.js
+++ b/src/utils/whisperRuntime.js
@@ -1,0 +1,67 @@
+const path = require('path');
+
+const HUGGING_FACE_MODEL_ID = /^(?:[\w.-]+\/)?[\w.-]{1,96}$/;
+const CACHE_CORRUPTION_PATTERNS = [
+    /protobuf parsing failed/i,
+    /invalid (?:protobuf|wire type)/i,
+    /onnx.*(?:corrupt|invalid|parsing failed)/i,
+    /(?:corrupt|invalid).*onnx/i,
+];
+
+function normalizeWhisperDevice(device, platform = process.platform) {
+    return device === 'dml' && platform === 'win32' ? 'dml' : 'cpu';
+}
+
+function getWhisperModelCachePath(cacheDir, modelName) {
+    if (
+        typeof modelName !== 'string' ||
+        !HUGGING_FACE_MODEL_ID.test(modelName) ||
+        modelName.includes('..') ||
+        modelName.includes('--') ||
+        modelName.endsWith('.git') ||
+        modelName.endsWith('.ipynb')
+    ) {
+        throw new Error('Invalid Whisper model ID');
+    }
+
+    const resolvedCacheDir = path.resolve(cacheDir);
+    const modelCachePath = path.resolve(resolvedCacheDir, ...modelName.split('/'));
+    if (!modelCachePath.startsWith(`${resolvedCacheDir}${path.sep}`)) {
+        throw new Error('Whisper model cache path is outside the cache directory');
+    }
+    return modelCachePath;
+}
+
+function isWhisperCacheCorruption(error) {
+    let current = error;
+    const messages = [];
+    while (current) {
+        if (typeof current.message === 'string') {
+            messages.push(current.message);
+        }
+        current = current.cause;
+    }
+    const combinedMessage = messages.join(' ');
+    return CACHE_CORRUPTION_PATTERNS.some(pattern => pattern.test(combinedMessage));
+}
+
+async function loadWhisperPipelineWithRecovery(loadPipeline, clearModelCache, onRecovery = () => {}) {
+    try {
+        return await loadPipeline();
+    } catch (error) {
+        if (!isWhisperCacheCorruption(error)) {
+            throw error;
+        }
+
+        await onRecovery(error);
+        await clearModelCache();
+        return loadPipeline();
+    }
+}
+
+module.exports = {
+    getWhisperModelCachePath,
+    isWhisperCacheCorruption,
+    loadWhisperPipelineWithRecovery,
+    normalizeWhisperDevice,
+};

--- a/test/whisperRuntime.test.js
+++ b/test/whisperRuntime.test.js
@@ -65,3 +65,18 @@ test('does not clear or retry for unrelated failures', async () => {
     );
     assert.equal(clearCount, 0);
 });
+
+test('stops after one retry when the fresh model also fails', async () => {
+    let loadCount = 0;
+    await assert.rejects(
+        loadWhisperPipelineWithRecovery(
+            async () => {
+                loadCount += 1;
+                throw new Error('Protobuf parsing failed');
+            },
+            async () => {}
+        ),
+        /Protobuf parsing failed/
+    );
+    assert.equal(loadCount, 2);
+});

--- a/test/whisperRuntime.test.js
+++ b/test/whisperRuntime.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {
+    getWhisperModelCachePath,
+    isWhisperCacheCorruption,
+    loadWhisperPipelineWithRecovery,
+    normalizeWhisperDevice,
+} = require('../src/utils/whisperRuntime');
+
+test('uses CPU by default and only enables DirectML on Windows', () => {
+    assert.equal(normalizeWhisperDevice('auto', 'win32'), 'cpu');
+    assert.equal(normalizeWhisperDevice('dml', 'win32'), 'dml');
+    assert.equal(normalizeWhisperDevice('dml', 'darwin'), 'cpu');
+});
+
+test('resolves valid model cache paths and rejects traversal', () => {
+    assert.equal(getWhisperModelCachePath('/tmp/whisper-models', 'Xenova/whisper-small'), path.resolve('/tmp/whisper-models/Xenova/whisper-small'));
+    assert.throws(() => getWhisperModelCachePath('/tmp/whisper-models', '../../private'), /Invalid Whisper model ID/);
+});
+
+test('recognizes nested ONNX protobuf corruption errors', () => {
+    const error = new Error('Model initialization failed', { cause: new Error('Protobuf parsing failed for decoder_model.onnx') });
+    assert.equal(isWhisperCacheCorruption(error), true);
+    assert.equal(isWhisperCacheCorruption(new Error('Network request failed')), false);
+});
+
+test('clears a corrupt model cache and retries exactly once', async () => {
+    let loadCount = 0;
+    let clearCount = 0;
+    let recoveryCount = 0;
+
+    const result = await loadWhisperPipelineWithRecovery(
+        async () => {
+            loadCount += 1;
+            if (loadCount === 1) throw new Error('Protobuf parsing failed');
+            return 'pipeline';
+        },
+        async () => {
+            clearCount += 1;
+        },
+        async () => {
+            recoveryCount += 1;
+        }
+    );
+
+    assert.equal(result, 'pipeline');
+    assert.equal(loadCount, 2);
+    assert.equal(clearCount, 1);
+    assert.equal(recoveryCount, 1);
+});
+
+test('does not clear or retry for unrelated failures', async () => {
+    let clearCount = 0;
+    await assert.rejects(
+        loadWhisperPipelineWithRecovery(
+            async () => {
+                throw new Error('Network request failed');
+            },
+            async () => {
+                clearCount += 1;
+            }
+        ),
+        /Network request failed/
+    );
+    assert.equal(clearCount, 0);
+});


### PR DESCRIPTION
## Summary

- default Whisper to the stable CPU backend instead of automatic DirectML selection
- expose DirectML as an explicit experimental Windows option for users who want GPU acceleration
- validate local-session IPC input and enforce the DirectML platform restriction in both processes
- detect ONNX/protobuf cache corruption, delete only the selected model cache, and retry exactly once
- validate the model cache path before deletion so a stored model value cannot escape the cache root
- serialize concurrent loads, share failures with all waiters, and abort replacement if native pipeline disposal fails
- reload the pipeline when the selected model or device changes

The recovery path only removes downloaded model cache data. Transformers.js downloads a fresh copy immediately, so no user-created data is deleted.

## Verification

- `node --test` (6 passing tests)
- `node --check` for all changed JavaScript modules
- `npm run lint`
- `npm run package`
- `npm start`

Fixes #239
Refs #373, #421