### PR TITLE
fix(deps): update vulnerable runtime packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,47 +9,45 @@
             "version": "0.7.0",
             "license": "GPL-3.0",
             "dependencies": {
-                "@google/genai": "^1.2.0",
+                "@google/genai": "^1.52.0",
                 "@huggingface/transformers": "^3.8.1",
                 "electron-squirrel-startup": "^1.0.1",
                 "ollama": "^0.6.3",
-                "ws": "^8.19.0"
+                "ws": "^8.21.1"
             },
             "devDependencies": {
-                "@electron-forge/cli": "^7.8.1",
-                "@electron-forge/maker-deb": "^7.8.1",
-                "@electron-forge/maker-dmg": "^7.8.1",
-                "@electron-forge/maker-rpm": "^7.8.1",
-                "@electron-forge/maker-squirrel": "^7.8.1",
-                "@electron-forge/maker-zip": "^7.8.1",
-                "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
-                "@electron-forge/plugin-fuses": "^7.8.1",
+                "@electron-forge/cli": "^7.11.2",
+                "@electron-forge/maker-deb": "^7.11.2",
+                "@electron-forge/maker-dmg": "^7.11.2",
+                "@electron-forge/maker-rpm": "^7.11.2",
+                "@electron-forge/maker-squirrel": "^7.11.2",
+                "@electron-forge/maker-zip": "^7.11.2",
+                "@electron-forge/plugin-auto-unpack-natives": "^7.11.2",
+                "@electron-forge/plugin-fuses": "^7.11.2",
                 "@electron/fuses": "^1.8.0",
                 "@reforged/maker-appimage": "^5.0.0",
-                "electron": "^30.0.5"
+                "electron": "^43.1.1"
             }
         },
         "node_modules/@electron-forge/cli": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.8.1.tgz",
-            "integrity": "sha512-QI3EShutfq9Y+2TWWrPjm4JZM3eSAKzoQvRZdVhAfVpUbyJ8K23VqJShg3kGKlPf9BXHAGvE+8LyH5s2yDr1qA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.2.tgz",
+            "integrity": "sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==",
             "dev": true,
             "funding": [
                 {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/malept"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-cli?utm_medium=referral&utm_source=npm_fund"
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/electron"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/core": "7.8.1",
-                "@electron-forge/core-utils": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/core": "7.11.2",
+                "@electron-forge/core-utils": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
                 "@electron/get": "^3.0.0",
+                "@inquirer/prompts": "^6.0.1",
+                "@listr2/prompt-adapter-inquirer": "^2.0.22",
                 "chalk": "^4.0.0",
                 "commander": "^11.1.0",
                 "debug": "^4.3.1",
@@ -93,39 +91,37 @@
             "license": "MIT"
         },
         "node_modules/@electron-forge/core": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.8.1.tgz",
-            "integrity": "sha512-jkh0QPW5p0zmruu1E8+2XNufc4UMxy13WLJcm7hn9jbaXKLkMbKuEvhrN1tH/9uGp1mhr/t8sC4N67gP+gS87w==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.2.tgz",
+            "integrity": "sha512-RbOvlCahSlYBkY1XFgD5QuoifZltEY3ezYGqJYnV1z6RiUK1DfUXwdidmclBLI9d6u8NNr9xWPv79LHVc9ZA3Q==",
             "dev": true,
             "funding": [
                 {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/malept"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-core?utm_medium=referral&utm_source=npm_fund"
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/electron"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/core-utils": "7.8.1",
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/plugin-base": "7.8.1",
-                "@electron-forge/publisher-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
-                "@electron-forge/template-base": "7.8.1",
-                "@electron-forge/template-vite": "7.8.1",
-                "@electron-forge/template-vite-typescript": "7.8.1",
-                "@electron-forge/template-webpack": "7.8.1",
-                "@electron-forge/template-webpack-typescript": "7.8.1",
-                "@electron-forge/tracer": "7.8.1",
+                "@electron-forge/core-utils": "7.11.2",
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/plugin-base": "7.11.2",
+                "@electron-forge/publisher-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
+                "@electron-forge/template-base": "7.11.2",
+                "@electron-forge/template-vite": "7.11.2",
+                "@electron-forge/template-vite-typescript": "7.11.2",
+                "@electron-forge/template-webpack": "7.11.2",
+                "@electron-forge/template-webpack-typescript": "7.11.2",
+                "@electron-forge/tracer": "7.11.2",
                 "@electron/get": "^3.0.0",
                 "@electron/packager": "^18.3.5",
                 "@electron/rebuild": "^3.7.0",
                 "@malept/cross-spawn-promise": "^2.0.0",
+                "@vscode/sudo-prompt": "^9.3.1",
                 "chalk": "^4.0.0",
                 "debug": "^4.3.1",
+                "eta": "^3.5.0",
                 "fast-glob": "^3.2.7",
                 "filenamify": "^4.1.0",
                 "find-up": "^5.0.0",
@@ -135,13 +131,11 @@
                 "interpret": "^3.1.1",
                 "jiti": "^2.4.2",
                 "listr2": "^7.0.2",
-                "lodash": "^4.17.20",
                 "log-symbols": "^4.0.0",
                 "node-fetch": "^2.6.7",
                 "rechoir": "^0.8.0",
                 "semver": "^7.2.1",
                 "source-map-support": "^0.5.13",
-                "sudo-prompt": "^9.1.1",
                 "username": "^5.1.0"
             },
             "engines": {
@@ -149,13 +143,13 @@
             }
         },
         "node_modules/@electron-forge/core-utils": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.8.1.tgz",
-            "integrity": "sha512-mRoPLDNZgmjyOURE/K0D3Op53XGFmFRgfIvFC7c9S/BqsRpovVblrqI4XxPRdNmH9dvhd8On9gGz+XIYAKD3aQ==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.2.tgz",
+            "integrity": "sha512-/Fpwo44an6ulUdq94co5OOcbRCohgYNci/E6eoZZuTO9f72X+PqJkMkghqkMX3iQ8Aq2QRLkGKFwrKWJNTjL7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/shared-types": "7.11.2",
                 "@electron/rebuild": "^3.7.0",
                 "@malept/cross-spawn-promise": "^2.0.0",
                 "chalk": "^4.0.0",
@@ -163,6 +157,7 @@
                 "find-up": "^5.0.0",
                 "fs-extra": "^10.0.0",
                 "log-symbols": "^4.0.0",
+                "parse-author": "^2.0.0",
                 "semver": "^7.2.1"
             },
             "engines": {
@@ -170,9 +165,9 @@
             }
         },
         "node_modules/@electron-forge/core-utils/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -195,9 +190,9 @@
             "license": "MIT"
         },
         "node_modules/@electron-forge/core/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -220,13 +215,13 @@
             "license": "MIT"
         },
         "node_modules/@electron-forge/maker-base": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.8.1.tgz",
-            "integrity": "sha512-GUZqschGuEBzSzE0bMeDip65IDds48DZXzldlRwQ+85SYVA6RMU2AwDDqx3YiYsvP2OuxKruuqIJZtOF5ps4FQ==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.2.tgz",
+            "integrity": "sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/shared-types": "7.11.2",
                 "fs-extra": "^10.0.0",
                 "which": "^2.0.2"
             },
@@ -235,14 +230,14 @@
             }
         },
         "node_modules/@electron-forge/maker-deb": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.8.1.tgz",
-            "integrity": "sha512-tjjeesQtCP5Xht1X7gl4+K9bwoETPmQfBkOVAY/FZIxPj40uQh/hOUtLX2tYENNGNVZ1ryDYRs8TuPi+I41Vfw==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.2.tgz",
+            "integrity": "sha512-MYSdCTsqzKNmsmaq7CIFh2kJdBWUZ4njxnVGrIRClzueVITk5Kots3+eQo+e5QQLvXTVn2XTNDc2nYjvtBh+Mw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
@@ -252,14 +247,14 @@
             }
         },
         "node_modules/@electron-forge/maker-dmg": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.8.1.tgz",
-            "integrity": "sha512-l449QvY2Teu+J9rHnjkTHEm/wOJ1LRfmrQ2QkGtFoTRcqvFWdUAEN8nK2/08w3j2h6tvOY3QSUjRzXrhJZRNRA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.2.tgz",
+            "integrity": "sha512-vh8/mnu3xyMbRcz3S0TV1rB7ZyGhMK60Yz2f2R+Zmj1EbAivLEq5UAvzHdB+kLttr0Dpjp2FIX4TcZ9neD4Y9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
                 "fs-extra": "^10.0.0"
             },
             "engines": {
@@ -270,14 +265,14 @@
             }
         },
         "node_modules/@electron-forge/maker-rpm": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.8.1.tgz",
-            "integrity": "sha512-TF6wylft3BHkw9zdHcxmjEPBZYgTIc0jE31skFnMEQ/aExbNRiNaCZvsXy+7ptTWZxhxUKRc9KHhLFRMCmOK8g==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.2.tgz",
+            "integrity": "sha512-BEj/DcW6bSpmOyKUa3UsOgT7Hm3ZuP0Wa6OuQEunjxeCWn7yoDTDtjuYA0xRvzk+T4NCyDO3RBGjy6nYNSPU2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
@@ -287,14 +282,14 @@
             }
         },
         "node_modules/@electron-forge/maker-squirrel": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.8.1.tgz",
-            "integrity": "sha512-qT1PMvT7ALF0ONOkxlA0oc0PiFuKCAKgoMPoxYo9gGOqFvnAb+TBcnLxflQ4ashE/ZkrHpykr4LcDJxqythQTA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.2.tgz",
+            "integrity": "sha512-4CILo57ZDEQH1mJxjhYCSXuv+WaU7oPq67KqiTLEUOEzmiPg9u9/z7FXE34H/Tn5aKWN3dy+ngAETzv6iERCGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
                 "fs-extra": "^10.0.0"
             },
             "engines": {
@@ -305,14 +300,14 @@
             }
         },
         "node_modules/@electron-forge/maker-zip": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.8.1.tgz",
-            "integrity": "sha512-unIxEoV1lnK4BLVqCy3L2y897fTyg8nKY1WT4rrpv0MUKnQG4qmigDfST5zZNNHHaulEn/ElAic2GEiP7d6bhQ==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.2.tgz",
+            "integrity": "sha512-FWnOm2MORX/nt8psnEtID3Vnt8Blby1NkzjU3KjXBPF9kave71C3lI8KbBbCeKKyTQ/S00i2FiglKdRWQ1WNTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/maker-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/maker-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
                 "cross-zip": "^4.0.0",
                 "fs-extra": "^10.0.0",
                 "got": "^11.8.5"
@@ -322,70 +317,70 @@
             }
         },
         "node_modules/@electron-forge/plugin-auto-unpack-natives": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-auto-unpack-natives/-/plugin-auto-unpack-natives-7.8.1.tgz",
-            "integrity": "sha512-4URAgWX9qqqKe6Bfad0VmpFRrwINYMODfKGd2nFQrfHxmBtdpXnsWlLwVGE/wGssIQaTMI5bWQ6F2RNeXTgnhA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-auto-unpack-natives/-/plugin-auto-unpack-natives-7.11.2.tgz",
+            "integrity": "sha512-ktMQxO80vGjqVXVSFha+kWJscBmJaWud4Kqu7rKkbrCphr1zqaG+8EDNbkpGzV/+mhKOLuA5qII1hJ69gFNpdA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/plugin-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/plugin-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
             }
         },
         "node_modules/@electron-forge/plugin-base": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.8.1.tgz",
-            "integrity": "sha512-iCZC2d7CbsZ9l6j5d+KPIiyQx0U1QBfWAbKnnQhWCSizjcrZ7A9V4sMFZeTO6+PVm48b/r9GFPm+slpgZtYQLg==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.11.2.tgz",
+            "integrity": "sha512-tIFzEE2+D9NnCAn/rLwSkh8H59IqN+G973JNl7xmCzquO6qa7/veitZOQFGO79Zmmgkc8R/fmiCbh7LIdLS9Tg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
             }
         },
         "node_modules/@electron-forge/plugin-fuses": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-fuses/-/plugin-fuses-7.8.1.tgz",
-            "integrity": "sha512-dYTwvbV1HcDOIQ0wTybpdtPq6YoBYXIWBTb7DJuvFu/c/thj1eoEdnbwr8mT9hEivjlu5p4ls46n16P5EtZ0oA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/plugin-fuses/-/plugin-fuses-7.11.2.tgz",
+            "integrity": "sha512-Y65MwTmYY0ytwtUy+u9M77rEe8MeMdRR+V2IsjAozIzAVp/38NJXfF7+AqlqE9M/fDENjPuwKnrg2IOj9P1TRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/plugin-base": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/plugin-base": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
             },
             "peerDependencies": {
-                "@electron/fuses": ">=1.0.0"
+                "@electron/fuses": "^1.0.0"
             }
         },
         "node_modules/@electron-forge/publisher-base": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.8.1.tgz",
-            "integrity": "sha512-z2C+C4pcFxyCXIFwXGDcxhU8qtVUPZa3sPL6tH5RuMxJi77768chLw2quDWk2/dfupcSELXcOMYCs7aLysCzeQ==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.11.2.tgz",
+            "integrity": "sha512-YwK4ZF3+uW7PBEV/ho59NVTriP3fCahskORrztUaFIdG0QP3hqMsfmo01euv98FDsBEW9UXo7/EW8t5jpmYZ0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1"
+                "@electron-forge/shared-types": "7.11.2"
             },
             "engines": {
                 "node": ">= 16.4.0"
             }
         },
         "node_modules/@electron-forge/shared-types": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.8.1.tgz",
-            "integrity": "sha512-guLyGjIISKQQRWHX+ugmcjIOjn2q/BEzCo3ioJXFowxiFwmZw/oCZ2KlPig/t6dMqgUrHTH5W/F0WKu0EY4M+Q==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+            "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/tracer": "7.8.1",
+                "@electron-forge/tracer": "7.11.2",
                 "@electron/packager": "^18.3.5",
                 "@electron/rebuild": "^3.7.0",
                 "listr2": "^7.0.2"
@@ -395,17 +390,18 @@
             }
         },
         "node_modules/@electron-forge/template-base": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.8.1.tgz",
-            "integrity": "sha512-k8jEUr0zWFWb16ZGho+Es2OFeKkcbTgbC6mcH4eNyF/sumh/4XZMcwRtX1i7EiZAYiL9sVxyI6KVwGu254g+0g==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.2.tgz",
+            "integrity": "sha512-l10I+XZRbbxFGiDLMnuXmlOppmLYmimKj6FWjEGUvft4VJFXW2BIDrLIugIGdM1nbrl/0aYjen2xRg0nZlcWzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/core-utils": "7.8.1",
-                "@electron-forge/shared-types": "7.8.1",
+                "@electron-forge/core-utils": "7.11.2",
+                "@electron-forge/shared-types": "7.11.2",
                 "@malept/cross-spawn-promise": "^2.0.0",
                 "debug": "^4.3.1",
                 "fs-extra": "^10.0.0",
+                "semver": "^7.2.1",
                 "username": "^5.1.0"
             },
             "engines": {
@@ -413,9 +409,9 @@
             }
         },
         "node_modules/@electron-forge/template-base/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -438,14 +434,14 @@
             "license": "MIT"
         },
         "node_modules/@electron-forge/template-vite": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.8.1.tgz",
-            "integrity": "sha512-qzSlJaBYYqQAbBdLk4DqAE3HCNz4yXbpkb+VC74ddL4JGwPdPU57DjCthr6YetKJ2FsOVy9ipovA8HX5UbXpAg==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.2.tgz",
+            "integrity": "sha512-yFSDSu3IdyNpgLXzrwODSUyaWniHRSZI82gwcXdnJLx7D7DIDLtbx6KzEoy7QBmWZRULO3F7rLsYG+Ur7orvyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
-                "@electron-forge/template-base": "7.8.1",
+                "@electron-forge/shared-types": "7.11.2",
+                "@electron-forge/template-base": "7.11.2",
                 "fs-extra": "^10.0.0"
             },
             "engines": {
@@ -453,14 +449,14 @@
             }
         },
         "node_modules/@electron-forge/template-vite-typescript": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.8.1.tgz",
-            "integrity": "sha512-CccQhwUjZcc6svzuOi3BtbDal591DzyX2J5GPa6mwVutDP8EMtqJL1VyOHdcWO/7XjI6GNAD0fiXySOJiUAECA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.2.tgz",
+            "integrity": "sha512-QvvdmO9Gdv+3aISI9+bBLKPBTyKaucs6HhXxz+IDALcdykIL9wVN0/BrWuwwgbwuw4BiJTyXGSPNXuJ+EWnP6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
-                "@electron-forge/template-base": "7.8.1",
+                "@electron-forge/shared-types": "7.11.2",
+                "@electron-forge/template-base": "7.11.2",
                 "fs-extra": "^10.0.0"
             },
             "engines": {
@@ -468,14 +464,14 @@
             }
         },
         "node_modules/@electron-forge/template-webpack": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.8.1.tgz",
-            "integrity": "sha512-DA77o9kTCHrq+W211pyNP49DyAt0d1mzMp2gisyNz7a+iKvlv2DsMAeRieLoCQ44akb/z8ZsL0YLteSjKLy4AA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.2.tgz",
+            "integrity": "sha512-JjG8XIZctrSZvTlii7Hqvt/pHDKigRk4PoLTQCs1TiT05ZWsn40itBm8cbja3L7bfm0ccDd3JTWWOl2G7PhlmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
-                "@electron-forge/template-base": "7.8.1",
+                "@electron-forge/shared-types": "7.11.2",
+                "@electron-forge/template-base": "7.11.2",
                 "fs-extra": "^10.0.0"
             },
             "engines": {
@@ -483,24 +479,26 @@
             }
         },
         "node_modules/@electron-forge/template-webpack-typescript": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.8.1.tgz",
-            "integrity": "sha512-h922E+6zWwym1RT6WKD79BLTc4H8YxEMJ7wPWkBX59kw/exsTB/KFdiJq6r82ON5jSJ+Q8sDGqSmDWdyCfo+Gg==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.2.tgz",
+            "integrity": "sha512-2lwK+OrCeZgYM8WqsUXJzk94rdF0z/kA7WnAf79U3COEmAAMcFIwJtwF8c/n+52UecP3yrEE70LIGmM1sjGZJQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@electron-forge/shared-types": "7.8.1",
-                "@electron-forge/template-base": "7.8.1",
-                "fs-extra": "^10.0.0"
+                "@electron-forge/shared-types": "7.11.2",
+                "@electron-forge/template-base": "7.11.2",
+                "fs-extra": "^10.0.0",
+                "typescript": "~5.4.5",
+                "webpack": "^5.69.1"
             },
             "engines": {
                 "node": ">= 16.4.0"
             }
         },
         "node_modules/@electron-forge/tracer": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.8.1.tgz",
-            "integrity": "sha512-r2i7aHVp2fylGQSPDw3aTcdNfVX9cpL1iL2MKHrCRNwgrfR+nryGYg434T745GGm1rNQIv5Egdkh5G9xf00oWA==",
+            "version": "7.11.2",
+            "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+            "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -508,6 +506,16 @@
             },
             "engines": {
                 "node": ">= 14.17.5"
+            }
+        },
+        "node_modules/@electron-internal/extract-zip": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+            "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=22.12.0"
             }
         },
         "node_modules/@electron/asar": {
@@ -1127,21 +1135,27 @@
             "license": "MIT"
         },
         "node_modules/@google/genai": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.2.0.tgz",
-            "integrity": "sha512-jAYhzG7UrLJxeQr5cfL87O4AcyEu+E7AA7MJDYPrDWI3Hl25EAdx5mA4AuNfSXZO31LnSyrIkEzkmJOAdlPKOA==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+            "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+            "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "google-auth-library": "^9.14.2",
-                "ws": "^8.18.0",
-                "zod": "^3.22.4",
-                "zod-to-json-schema": "^3.22.4"
+                "google-auth-library": "^10.3.0",
+                "p-retry": "^4.6.2",
+                "protobufjs": "^7.5.4",
+                "ws": "^8.18.0"
             },
             "engines": {
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@modelcontextprotocol/sdk": "^1.11.0"
+                "@modelcontextprotocol/sdk": "^1.25.2"
+            },
+            "peerDependenciesMeta": {
+                "@modelcontextprotocol/sdk": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@huggingface/jinja": {
@@ -1630,6 +1644,426 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@inquirer/checkbox": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+            "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/figures": "^1.0.6",
+                "@inquirer/type": "^2.0.0",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+            "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+            "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/figures": "^1.0.6",
+                "@inquirer/type": "^2.0.0",
+                "@types/mute-stream": "^0.0.4",
+                "@types/node": "^22.5.5",
+                "@types/wrap-ansi": "^3.0.0",
+                "ansi-escapes": "^4.3.2",
+                "cli-width": "^4.1.0",
+                "mute-stream": "^1.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@inquirer/core/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/editor": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+            "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0",
+                "external-editor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/expand": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+            "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/figures": {
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+            "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/number": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+            "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/password": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+            "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0",
+                "ansi-escapes": "^4.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/prompts": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+            "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/checkbox": "^3.0.1",
+                "@inquirer/confirm": "^4.0.1",
+                "@inquirer/editor": "^3.0.1",
+                "@inquirer/expand": "^3.0.1",
+                "@inquirer/input": "^3.0.1",
+                "@inquirer/number": "^2.0.1",
+                "@inquirer/password": "^3.0.1",
+                "@inquirer/rawlist": "^3.0.1",
+                "@inquirer/search": "^2.0.1",
+                "@inquirer/select": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/rawlist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+            "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/type": "^2.0.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/search": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+            "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/figures": "^1.0.6",
+                "@inquirer/type": "^2.0.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+            "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^9.2.1",
+                "@inquirer/figures": "^1.0.6",
+                "@inquirer/type": "^2.0.0",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+            "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mute-stream": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@isaacs/fs-minipass": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1649,6 +2083,85 @@
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@listr2/prompt-adapter-inquirer": {
+            "version": "2.0.22",
+            "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-2.0.22.tgz",
+            "integrity": "sha512-hV36ZoY+xKL6pYOt1nPNnkciFkn89KZwqLhAFzJvYysAvL5uBQdiADZx/8bIDXIukzzwG0QlPYolgMzQUtKgpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/type": "^1.5.5"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "@inquirer/prompts": ">= 3 < 8"
+            }
+        },
+        "node_modules/@listr2/prompt-adapter-inquirer/node_modules/@inquirer/type": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+            "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mute-stream": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@malept/cross-spawn-promise": {
@@ -1672,30 +2185,6 @@
             },
             "engines": {
                 "node": ">= 12.13.0"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
-            "integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ajv": "^6.12.6",
-                "content-type": "^1.0.5",
-                "cors": "^2.8.5",
-                "cross-spawn": "^7.0.5",
-                "eventsource": "^3.0.2",
-                "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
-                "pkce-challenge": "^5.0.0",
-                "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1778,37 +2267,30 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1824,9 +2306,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@reforged/maker-appimage": {
@@ -1927,6 +2409,13 @@
                 "@types/responselike": "^1.0.0"
             }
         },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -1945,10 +2434,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/keyv": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
             "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/mute-stream": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+            "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1974,6 +2480,19 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/wrap-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+            "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -1983,6 +2502,174 @@
             "optional": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@vscode/sudo-prompt": {
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
+            "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@xmldom/xmldom": {
@@ -1995,6 +2682,20 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2002,28 +2703,30 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/accepts": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+        "node_modules/acorn": {
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mime-types": "^3.0.0",
-                "negotiator": "^1.0.0"
+            "bin": {
+                "acorn": "bin/acorn"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=0.4.0"
             }
         },
-        "node_modules/accepts/node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/agent-base": {
@@ -2092,20 +2795,51 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
             }
         },
         "node_modules/ansi-escapes": {
@@ -2249,10 +2983,23 @@
             ],
             "license": "MIT"
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/bignumber.js": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-            "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -2276,52 +3023,6 @@
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
-                "debug": "^4.4.0",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
-                "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/body-parser/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/body-parser/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/boolean": {
             "version": "3.2.0",
@@ -2363,6 +3064,40 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
         "node_modules/buffer": {
@@ -2412,16 +3147,6 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/cacache": {
             "version": "16.1.3",
@@ -2526,36 +3251,26 @@
                 "node": ">=8"
             }
         },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2573,6 +3288,13 @@
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
+        },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/chownr": {
             "version": "2.0.0",
@@ -2648,6 +3370,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/cliui": {
@@ -2815,63 +3547,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/content-type": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/cookie-signature": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.6.0"
-            }
-        },
-        "node_modules/cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/cross-dirname": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
@@ -2883,6 +3558,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2915,6 +3591,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.10"
+            }
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/debug": {
@@ -3012,16 +3697,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3061,21 +3736,6 @@
                 "tn1150": "^0.1.0"
             }
         },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3092,30 +3752,23 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "node_modules/ee-first": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/electron": {
-            "version": "30.5.1",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-30.5.1.tgz",
-            "integrity": "sha512-AhL7+mZ8Lg14iaNfoYTkXQ2qee8mmsQyllKdqxlpv/zrKgfxz6jNVtcRRbQtLxtF8yzcImWdfTQROpYiPumdbw==",
+            "version": "43.1.1",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
+            "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@electron/get": "^2.0.0",
-                "@types/node": "^20.9.0",
-                "extract-zip": "^2.0.1"
+                "@electron-internal/extract-zip": "^1.0.1",
+                "@electron/get": "^5.0.0",
+                "@types/node": "^24.9.0"
             },
             "bin": {
-                "electron": "cli.js"
+                "electron": "cli.js",
+                "install-electron": "install.js"
             },
             "engines": {
-                "node": ">= 12.20.55"
+                "node": ">= 22.12.0"
             }
         },
         "node_modules/electron-installer-common": {
@@ -3709,6 +4362,13 @@
                 "debug": "^2.2.0"
             }
         },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.393",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+            "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/electron-winstaller": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -3797,41 +4457,40 @@
             }
         },
         "node_modules/electron/node_modules/@electron/get": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-            "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+            "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.1",
-                "env-paths": "^2.2.0",
-                "fs-extra": "^8.1.0",
-                "got": "^11.8.5",
+                "env-paths": "^3.0.0",
+                "graceful-fs": "^4.2.11",
                 "progress": "^2.0.3",
-                "semver": "^6.2.0",
+                "semver": "^7.6.3",
                 "sumchecker": "^3.0.1"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=22.12.0"
             },
             "optionalDependencies": {
-                "global-agent": "^3.0.0"
+                "undici": "^7.24.4"
             }
         },
         "node_modules/electron/node_modules/@types/node": {
-            "version": "20.17.52",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.52.tgz",
-            "integrity": "sha512-2aj++KfxubvW/Lc0YyXE3OEW7Es8TWn1MsRzYgcOGyTNQxi0L8rxQUCZ7ZbyOBWZQD5I63PV9egZWMsapVaklg==",
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/electron/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3846,29 +4505,17 @@
                 }
             }
         },
-        "node_modules/electron/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+        "node_modules/electron/node_modules/env-paths": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
             "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/electron/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/electron/node_modules/ms": {
@@ -3878,32 +4525,12 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/electron/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/electron/node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/electron/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -3920,20 +4547,11 @@
             "license": "MIT",
             "optional": true
         },
-        "node_modules/encodeurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/encoding": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3948,6 +4566,20 @@
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.24.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/env-paths": {
@@ -3995,18 +4627,12 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es6-error": {
             "version": "4.1.1",
@@ -4024,13 +4650,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/escape-html": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4043,14 +4662,64 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/etag": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-            "license": "MIT",
-            "peer": true,
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/eta": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-3.5.0.tgz",
+            "integrity": "sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/eta-dev/eta?sponsor=1"
             }
         },
         "node_modules/eventemitter3": {
@@ -4060,27 +4729,14 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/eventsource": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "eventsource-parser": "^3.0.1"
-            },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/eventsource-parser": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
-            "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=20.0.0"
+                "node": ">=0.8.x"
             }
         },
         "node_modules/execa": {
@@ -4195,95 +4851,52 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
-                "content-disposition": "^1.0.0",
-                "content-type": "^1.0.5",
-                "cookie": "^0.7.1",
-                "cookie-signature": "^1.2.1",
-                "debug": "^4.4.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "finalhandler": "^2.1.0",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "merge-descriptors": "^2.0.0",
-                "mime-types": "^3.0.0",
-                "on-finished": "^2.4.1",
-                "once": "^1.4.0",
-                "parseurl": "^1.3.3",
-                "proxy-addr": "^2.0.7",
-                "qs": "^6.14.0",
-                "range-parser": "^1.2.1",
-                "router": "^2.2.0",
-                "send": "^1.1.0",
-                "serve-static": "^2.2.0",
-                "statuses": "^2.0.1",
-                "type-is": "^2.0.1",
-                "vary": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/express-rate-limit"
-            },
-            "peerDependencies": {
-                "express": ">= 4.11"
-            }
-        },
-        "node_modules/express/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/express/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
+        },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/external-editor/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/external-editor/node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
@@ -4335,8 +4948,8 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -4355,17 +4968,27 @@
                 "node": ">=8.6.0"
             }
         },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "license": "MIT",
-            "peer": true
+        "node_modules/fast-uri": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4380,6 +5003,29 @@
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/filename-reserved-regex": {
@@ -4422,49 +5068,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.4.0",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "on-finished": "^2.4.1",
-                "parseurl": "^1.3.3",
-                "statuses": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/finalhandler/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/finalhandler/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -4539,24 +5142,16 @@
                 "imul": "^1.0.0"
             }
         },
-        "node_modules/forwarded": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
             "license": "MIT",
-            "peer": true,
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
             "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/fresh": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fs-extra": {
@@ -4624,6 +5219,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4679,34 +5275,32 @@
             "optional": true
         },
         "node_modules/gaxios": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+            "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^7.0.1",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.9",
-                "uuid": "^9.0.1"
+                "node-fetch": "^3.3.2"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/gaxios/node_modules/agent-base": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/gaxios/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -4733,36 +5327,42 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/gaxios/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gaxios/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
+        "node_modules/gaxios/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
         "node_modules/gcp-metadata": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+            "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "gaxios": "^6.1.1",
-                "google-logging-utils": "^0.0.2",
+                "gaxios": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
                 "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/generate-function": {
@@ -4812,31 +5412,6 @@
                 "get-folder-size": "bin/get-folder-size"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-package-info": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-package-info/-/get-package-info-1.0.0.tgz",
@@ -4851,20 +5426,6 @@
             },
             "engines": {
                 "node": ">= 4.0"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4968,26 +5529,26 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "9.15.1",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "version": "10.9.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+            "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "gaxios": "^6.1.1",
-                "gcp-metadata": "^6.1.0",
-                "gtoken": "^7.0.0",
+                "gaxios": "^7.1.4",
+                "gcp-metadata": "8.1.2",
+                "google-logging-utils": "1.1.3",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/google-logging-utils": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -5038,19 +5599,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/gtoken": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "gaxios": "^6.0.0",
-                "jws": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/guid-typescript": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
@@ -5079,23 +5627,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -5117,33 +5653,6 @@
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "dev": true,
             "license": "BSD-2-Clause"
-        },
-        "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-errors/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/http-proxy-agent": {
             "version": "5.0.0",
@@ -5252,7 +5761,9 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -5349,6 +5860,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -5383,16 +5895,6 @@
             },
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.10"
             }
         },
         "node_modules/is-arrayish": {
@@ -5504,13 +6006,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-promise": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -5559,12 +6054,44 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
             "license": "ISC"
         },
+        "node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/jiti": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5595,11 +6122,11 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "license": "MIT",
-            "peer": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
@@ -5653,12 +6180,12 @@
             }
         },
         "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "license": "MIT",
             "dependencies": {
-                "jwa": "^2.0.0",
+                "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -5706,6 +6233,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5727,7 +6268,8 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/lodash.get": {
             "version": "4.4.2",
@@ -5868,26 +6410,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/mem": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -5903,18 +6425,12 @@
                 "node": ">=6"
             }
         },
-        "node_modules/merge-descriptors": {
+        "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5944,21 +6460,8 @@
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mime-db": "^1.54.0"
-            },
             "engines": {
                 "node": ">= 0.6"
             }
@@ -6004,6 +6507,67 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
             }
         },
         "node_modules/minipass": {
@@ -6135,6 +6699,16 @@
                 "imul": "^1.0.0"
             }
         },
+        "node_modules/mute-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/nan": {
             "version": "2.22.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
@@ -6152,6 +6726,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -6183,10 +6764,31 @@
                 "semver": "^7.3.5"
             }
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -6201,6 +6803,16 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/nopt": {
@@ -6278,29 +6890,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -6319,23 +6908,11 @@
                 "whatwg-fetch": "^3.6.20"
             }
         },
-        "node_modules/on-finished": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ee-first": "1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -6411,9 +6988,9 @@
             }
         },
         "node_modules/onnxruntime-node/node_modules/tar": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-            "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+            "version": "7.5.20",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+            "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -6529,6 +7106,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/p-cancelable": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -6617,6 +7204,28 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-retry": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/retry": "0.12.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-retry/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -6671,16 +7280,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/parseurl": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6705,6 +7304,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6716,16 +7316,6 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/path-to-regexp": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=16"
-            }
         },
         "node_modules/path-type": {
             "version": "2.0.0",
@@ -6762,10 +7352,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6783,16 +7380,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pkce-challenge": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-            "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=16.20.0"
             }
         },
         "node_modules/platform": {
@@ -6884,41 +7471,26 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/proxy-addr": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "forwarded": "0.2.0",
-                "ipaddr.js": "1.9.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
             }
         },
         "node_modules/pump": {
@@ -6930,32 +7502,6 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -7002,32 +7548,6 @@
             "dependencies": {
                 "base32-encode": "^0.1.0 || ^1.0.0",
                 "murmur-32": "^0.1.0 || ^0.2.0"
-            }
-        },
-        "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/raw-body": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.6.3",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/read-binary-file-arch": {
@@ -7209,6 +7729,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resedit": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.3.tgz",
@@ -7347,48 +7877,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/router": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.4.0",
-                "depd": "^2.0.0",
-                "is-promise": "^4.0.0",
-                "parseurl": "^1.3.3",
-                "path-to-regexp": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/router/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/router/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7437,7 +7925,28 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -7456,54 +7965,6 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "license": "MIT"
-        },
-        "node_modules/send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.3.5",
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "etag": "^1.8.1",
-                "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
-                "ms": "^2.1.3",
-                "on-finished": "^2.4.1",
-                "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/send/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/serialize-error": {
             "version": "7.0.1",
@@ -7531,29 +7992,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "encodeurl": "^2.0.0",
-                "escape-html": "^1.0.3",
-                "parseurl": "^1.3.3",
-                "send": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "license": "ISC",
-            "peer": true
         },
         "node_modules/sharp": {
             "version": "0.34.5",
@@ -7603,6 +8041,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -7615,85 +8054,10 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/signal-exit": {
@@ -7875,16 +8239,6 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
-        "node_modules/statuses": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/stream-buffers": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -7983,14 +8337,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/sudo-prompt": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-            "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/sumchecker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -8053,6 +8399,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/tar": {
@@ -8127,6 +8487,32 @@
                 "rimraf": "bin.js"
             }
         },
+        "node_modules/terser": {
+            "version": "5.49.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tiny-each-async": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
@@ -8192,20 +8578,11 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/toidentifier": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/trim-repeated": {
@@ -8251,19 +8628,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "content-type": "^1.0.5",
-                "media-typer": "^1.1.0",
-                "mime-types": "^3.0.0"
+        "node_modules/typescript": {
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -8319,24 +8706,35 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
-                "punycode": "^2.1.0"
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
             }
         },
         "node_modules/username": {
@@ -8360,19 +8758,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -8384,14 +8769,17 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "node_modules/vary": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+        "node_modules/watchpack": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2"
+            },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/wcwidth": {
@@ -8404,11 +8792,77 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
             "license": "BSD-2-Clause"
+        },
+        "node_modules/webpack": {
+            "version": "5.108.4",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.16.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.22.2",
+                "es-module-lexer": "^2.1.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "graceful-fs": "^4.2.11",
+                "loader-runner": "^4.3.2",
+                "mime-db": "^1.54.0",
+                "minimizer-webpack-plugin": "^5.6.1",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "watchpack": "^2.5.2",
+                "webpack-sources": "^3.5.0"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-sources": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
         },
         "node_modules/whatwg-fetch": {
             "version": "3.6.20",
@@ -8420,6 +8874,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
@@ -8430,6 +8885,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -8487,12 +8943,13 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -8656,22 +9113,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/zod": {
-            "version": "3.25.36",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.36.tgz",
-            "integrity": "sha512-eRFS3i8T0IrpGdL8HQyqFAugGOn7jOjyGgGdtv5NY4Wkhi7lJDk732bNZ609YMIGFbLoaj6J69O1Mura23gfIw==",
+        "node_modules/yoctocolors-cjs": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+            "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.24.5",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-            "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.24.1"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -24,23 +24,29 @@
     },
     "license": "GPL-3.0",
     "dependencies": {
-        "@google/genai": "^1.2.0",
+        "@google/genai": "^1.52.0",
         "@huggingface/transformers": "^3.8.1",
         "electron-squirrel-startup": "^1.0.1",
         "ollama": "^0.6.3",
-        "ws": "^8.19.0"
+        "ws": "^8.21.1"
     },
     "devDependencies": {
-        "@electron-forge/cli": "^7.8.1",
-        "@electron-forge/maker-deb": "^7.8.1",
-        "@electron-forge/maker-dmg": "^7.8.1",
-        "@electron-forge/maker-rpm": "^7.8.1",
-        "@electron-forge/maker-squirrel": "^7.8.1",
-        "@electron-forge/maker-zip": "^7.8.1",
-        "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
-        "@electron-forge/plugin-fuses": "^7.8.1",
+        "@electron-forge/cli": "^7.11.2",
+        "@electron-forge/maker-deb": "^7.11.2",
+        "@electron-forge/maker-dmg": "^7.11.2",
+        "@electron-forge/maker-rpm": "^7.11.2",
+        "@electron-forge/maker-squirrel": "^7.11.2",
+        "@electron-forge/maker-zip": "^7.11.2",
+        "@electron-forge/plugin-auto-unpack-natives": "^7.11.2",
+        "@electron-forge/plugin-fuses": "^7.11.2",
         "@electron/fuses": "^1.8.0",
         "@reforged/maker-appimage": "^5.0.0",
-        "electron": "^30.0.5"
+        "electron": "^43.1.1"
+    },
+    "overrides": {
+        "protobufjs": "^7.6.5",
+        "onnxruntime-node": {
+            "tar": "^7.5.20"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- upgrade Electron from 30.5.1 to 43.1.1
- upgrade `ws` to 8.21.1 and `@google/genai` to the current compatible 1.x release
- update Electron Forge packages from 7.8.1 to 7.11.2
- constrain protobufjs and ONNX tar transitive dependencies to patched releases within compatible major versions
- regenerate the lockfile from a clean install

## Audit results

| Audit | Before | After |
| --- | ---: | ---: |
| `npm audit --omit=dev` | 12 (1 critical, 5 high, 6 moderate) | **0** |
| Full `npm audit` | 46 | 36 |

Electron, `ws`, and `protobufjs` no longer appear in the full audit report. The remaining findings are confined to Electron Forge/AppImage development tooling and currently have no non-breaking resolution; they are not included in the packaged production dependencies.

## Verification

- `npm ci`
- runtime module export checks for `@google/genai`, `ws`, and `protobufjs`
- `npm audit --omit=dev --audit-level=low`
- `npm run lint`
- `npm run package`
- `npm start` with Electron 43.1.1

Fixes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application and development tooling dependencies.
  * Improved compatibility and stability across packaged desktop builds.
  * Applied security and reliability updates to supporting libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->