### PR TITLE
feat: Linux system audio capture via PipeWire

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -4,7 +4,8 @@ const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 module.exports = {
     packagerConfig: {
         asar: true,
-        extraResource: ['./src/assets/SystemAudioDump'],
+        // SystemAudioDump is a macOS-only helper binary
+        extraResource: process.platform === 'darwin' ? ['./src/assets/SystemAudioDump'] : [],
         name: 'Cheating Daddy',
         icon: 'src/assets/logo',
         // use `security find-identity -v -p codesigning` to find your identity

--- a/src/components/views/MainView.js
+++ b/src/components/views/MainView.js
@@ -761,11 +761,19 @@ export class MainView extends LitElement {
             // Local AI is not available on Linux yet - fall back to BYOK
             if (cheatingDaddy.isLinux && this._mode === 'local') {
                 this._mode = 'byok';
-                await cheatingDaddy.storage.updatePreference('providerMode', 'byok');
+                try {
+                    await cheatingDaddy.storage.updatePreference('providerMode', 'byok');
+                } catch (error) {
+                    console.warn('Could not persist Linux provider-mode migration:', error);
+                }
             }
 
             if (storedMode === 'cloud') {
-                await cheatingDaddy.storage.updatePreference('providerMode', this._mode);
+                try {
+                    await cheatingDaddy.storage.updatePreference('providerMode', this._mode);
+                } catch (error) {
+                    console.warn('Could not persist cloud-mode migration:', error);
+                }
             }
 
             // Load keys

--- a/src/components/views/MainView.js
+++ b/src/components/views/MainView.js
@@ -758,6 +758,12 @@ export class MainView extends LitElement {
             const storedMode = prefs.providerMode || 'byok';
             this._mode = storedMode === 'cloud' ? 'byok' : storedMode;
 
+            // Local AI is not available on Linux yet - fall back to BYOK
+            if (cheatingDaddy.isLinux && this._mode === 'local') {
+                this._mode = 'byok';
+                await cheatingDaddy.storage.updatePreference('providerMode', 'byok');
+            }
+
             if (storedMode === 'cloud') {
                 await cheatingDaddy.storage.updatePreference('providerMode', this._mode);
             }
@@ -915,6 +921,10 @@ export class MainView extends LitElement {
     // ── Persistence ──
 
     async _saveMode(mode) {
+        if (cheatingDaddy.isLinux && mode === 'local') {
+            console.warn('Local AI is not available on Linux');
+            return;
+        }
         this._mode = mode;
         this._tokenError = false;
         this._keyError = false;
@@ -1237,9 +1247,15 @@ export class MainView extends LitElement {
 
             <!-- Cloud promo intentionally removed from the active UI. -->
 
-            <div class="mode-links">
-                <button class="mode-link" @click=${() => this._saveMode('local')}>Use local AI</button>
-            </div>
+            ${
+                cheatingDaddy.isLinux
+                    ? ''
+                    : html`
+                          <div class="mode-links">
+                              <button class="mode-link" @click=${() => this._saveMode('local')}>Use local AI</button>
+                          </div>
+                      `
+            }
         `;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,20 @@
+// Prevent uncaught EPIPE crashes when stdout/stderr pipes are closed
+// (e.g. app launched from a desktop entry or a pipe whose reader exited)
+for (const stream of [process.stdout, process.stderr]) {
+    stream.on('error', error => {
+        if (error && error.code === 'EPIPE') return;
+        throw error;
+    });
+}
+
 if (require('electron-squirrel-startup')) {
     process.exit(0);
 }
 
 const { app, BrowserWindow, shell, ipcMain } = require('electron');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
-const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
+const { setupGeminiIpcHandlers, stopMacOSAudioCapture, stopLinuxAudioCapture, sendToRenderer } = require('./utils/gemini');
+const linuxAudio = require('./utils/linuxAudio');
 const storage = require('./storage');
 
 const geminiSessionRef = { current: null };
@@ -18,6 +28,13 @@ function createMainWindow() {
 app.whenReady().then(async () => {
     // Initialize storage (checks version, resets if needed)
     storage.initializeStorage();
+
+    // Clean up leftover interception modules from a crashed previous session
+    if (process.platform === 'linux') {
+        linuxAudio.recoverStaleInterception().catch(error => {
+            console.warn('Interception recovery failed:', error.message);
+        });
+    }
 
     // Trigger screen recording permission prompt on macOS if not already granted
     if (process.platform === 'darwin') {
@@ -33,6 +50,7 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
     stopMacOSAudioCapture();
+    stopLinuxAudioCapture();
     if (process.platform !== 'darwin') {
         app.quit();
     }
@@ -40,6 +58,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
     stopMacOSAudioCapture();
+    stopLinuxAudioCapture();
     require('./utils/localai').closeLocalSession();
 });
 
@@ -267,6 +286,7 @@ function setupGeneralIpcHandlers() {
     ipcMain.handle('quit-application', async event => {
         try {
             stopMacOSAudioCapture();
+            stopLinuxAudioCapture();
             app.quit();
             return { success: true };
         } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ const storage = require('./storage');
 
 const geminiSessionRef = { current: null };
 let mainWindow = null;
+let quitCleanupStarted = false;
+let quitCleanupSettled = false;
 
 function createMainWindow() {
     mainWindow = createWindow(sendToRenderer, geminiSessionRef);
@@ -50,16 +52,35 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
     stopMacOSAudioCapture();
-    stopLinuxAudioCapture();
+    // Linux audio cleanup is awaited in before-quit
     if (process.platform !== 'darwin') {
         app.quit();
     }
 });
 
-app.on('before-quit', () => {
+app.on('before-quit', event => {
     stopMacOSAudioCapture();
-    stopLinuxAudioCapture();
     require('./utils/localai').closeLocalSession();
+
+    if (quitCleanupStarted) {
+        // A second quit trigger while cleanup is still running must not let
+        // Electron exit before the sink restore settles.
+        if (!quitCleanupSettled) event.preventDefault();
+        return;
+    }
+
+    // Restoring the default sink and unloading interception modules is async.
+    // Defer quitting until it settles, otherwise the process can exit first
+    // and leave the virtual sink as default with no audible output.
+    quitCleanupStarted = true;
+    event.preventDefault();
+    const cleanup = process.platform === 'linux' ? stopLinuxAudioCapture() : Promise.resolve();
+    cleanup
+        .catch(error => console.error('Error during quit audio cleanup:', error))
+        .finally(() => {
+            quitCleanupSettled = true;
+            app.quit();
+        });
 });
 
 app.on('activate', () => {
@@ -285,8 +306,7 @@ function setupGeneralIpcHandlers() {
 
     ipcMain.handle('quit-application', async event => {
         try {
-            stopMacOSAudioCapture();
-            stopLinuxAudioCapture();
+            // Async audio cleanup is handled by the before-quit handler
             app.quit();
             return { success: true };
         } catch (error) {

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -867,14 +867,14 @@ function killExistingSystemAudioDump() {
     });
 }
 
-function dispatchSystemAudioChunk(monoChunk, geminiSessionRef) {
+async function dispatchSystemAudioChunk(monoChunk, geminiSessionRef) {
     if (currentProviderMode === 'cloud') {
         sendCloudAudio(monoChunk);
     } else if (currentProviderMode === 'local') {
         getLocalAi().processLocalAudio(monoChunk);
     } else {
         const base64Data = monoChunk.toString('base64');
-        sendAudioToGemini(base64Data, geminiSessionRef);
+        await sendAudioToGemini(base64Data, geminiSessionRef);
     }
 
     if (process.env.DEBUG_AUDIO) {

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -23,6 +23,8 @@ let groqConversationHistory = [];
 
 // Conversation tracking variables
 let currentSessionId = null;
+const MIN_TRANSCRIPTION_LENGTH = 4;
+
 let currentTranscription = '';
 let conversationHistory = [];
 let screenAnalysisHistory = [];
@@ -218,7 +220,8 @@ function sendFinalTranscriptionToGroq() {
     }
 
     const transcription = currentTranscription.trim();
-    if (transcription === '') {
+    // Skip stray VAD fragments ("Ну", "И") - not worth a Groq request.
+    if (transcription.length < MIN_TRANSCRIPTION_LENGTH) {
         return;
     }
 
@@ -674,7 +677,8 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
                     console.log('----------------', message);
                     logTransportEvent('gemini.live.message', message);
 
-                    // Handle input transcription (what was spoken)
+                    // Accumulate input transcription (what was spoken); the
+                    // Groq request fires once per turn at the end markers below.
                     if (message.serverContent?.inputTranscription?.results) {
                         currentTranscription += formatSpeakerResults(message.serverContent.inputTranscription.results);
                     } else if (message.serverContent?.inputTranscription?.text) {
@@ -684,10 +688,6 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
                         }
                     }
 
-                    if (message.serverContent?.inputTranscription) {
-                        sendFinalTranscriptionToGroq();
-                    }
-
                     if (!hasGroqKey() && message.serverContent?.outputTranscription?.text) {
                         const isFirstChunk = messageBuffer === '';
                         messageBuffer += message.serverContent.outputTranscription.text;
@@ -695,6 +695,10 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
                     }
 
                     if (message.serverContent?.generationComplete) {
+                        // By this point the full user utterance for the turn has
+                        // been transcribed - send it once instead of per-fragment.
+                        sendFinalTranscriptionToGroq();
+
                         if (currentTranscription.trim() !== '') {
                             if (!hasGroqKey() && messageBuffer.trim() !== '') {
                                 saveConversationTurn(currentTranscription, messageBuffer);
@@ -705,6 +709,8 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
                     }
 
                     if (message.serverContent?.turnComplete) {
+                        // Safety net: flush if generationComplete never arrived.
+                        sendFinalTranscriptionToGroq();
                         currentTranscription = '';
                         messageBuffer = '';
                         groqRequestStartedForTurn = false;
@@ -745,6 +751,15 @@ async function initializeGeminiSession(apiKey, customPrompt = '', profile = 'int
                 responseModalities: [Modality.AUDIO],
                 proactivity: { proactiveAudio: true },
                 outputAudioTranscription: {},
+                realtimeInputConfig: {
+                    automaticActivityDetection: {
+                        disabled: false,
+                        // Require ~1.2s of silence before committing a turn so
+                        // natural mid-sentence pauses don't split the utterance.
+                        silenceDurationMs: 1200,
+                        prefixPaddingMs: 100,
+                    },
+                },
                 tools: enabledTools,
                 // Enable speaker diarization
                 inputAudioTranscription: {

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -6,6 +6,7 @@ const { getSystemPrompt } = require('./prompts');
 const { getAvailableModel, incrementLimitCount, getApiKey, getGroqApiKey, incrementCharUsage, getConfig } = require('../storage');
 const { connectCloud, sendCloudAudio, sendCloudText, sendCloudImage, closeCloud, isCloudActive, setOnTurnComplete } = require('./cloud');
 const { startTransportLog, logTransportEvent, closeTransportLog } = require('./transportLogger');
+const linuxAudio = require('./linuxAudio');
 
 // Lazy-loaded to avoid circular dependency (localai.js imports from gemini.js)
 let _localai = null;
@@ -866,6 +867,22 @@ function killExistingSystemAudioDump() {
     });
 }
 
+function dispatchSystemAudioChunk(monoChunk, geminiSessionRef) {
+    if (currentProviderMode === 'cloud') {
+        sendCloudAudio(monoChunk);
+    } else if (currentProviderMode === 'local') {
+        getLocalAi().processLocalAudio(monoChunk);
+    } else {
+        const base64Data = monoChunk.toString('base64');
+        sendAudioToGemini(base64Data, geminiSessionRef);
+    }
+
+    if (process.env.DEBUG_AUDIO) {
+        console.log(`Processed audio chunk: ${monoChunk.length} bytes`);
+        saveDebugAudio(monoChunk, 'system_audio');
+    }
+}
+
 async function startMacOSAudioCapture(geminiSessionRef) {
     if (process.platform !== 'darwin') return false;
 
@@ -919,19 +936,7 @@ async function startMacOSAudioCapture(geminiSessionRef) {
 
             const monoChunk = CHANNELS === 2 ? convertStereoToMono(chunk) : chunk;
 
-            if (currentProviderMode === 'cloud') {
-                sendCloudAudio(monoChunk);
-            } else if (currentProviderMode === 'local') {
-                getLocalAi().processLocalAudio(monoChunk);
-            } else {
-                const base64Data = monoChunk.toString('base64');
-                sendAudioToGemini(base64Data, geminiSessionRef);
-            }
-
-            if (process.env.DEBUG_AUDIO) {
-                console.log(`Processed audio chunk: ${chunk.length} bytes`);
-                saveDebugAudio(monoChunk, 'system_audio');
-            }
+            dispatchSystemAudioChunk(monoChunk, geminiSessionRef);
         }
 
         const maxBufferSize = SAMPLE_RATE * BYTES_PER_SAMPLE * 1;
@@ -1276,9 +1281,41 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
         }
     });
 
+    ipcMain.handle('start-linux-audio', async (event, options = {}) => {
+        if (process.platform !== 'linux') {
+            return { success: false, error: 'Linux audio capture only available on Linux' };
+        }
+
+        try {
+            return await linuxAudio.startLinuxAudioCapture({
+                mode: options.mode === 'intercept' ? 'intercept' : 'tap',
+                onChunk: chunk => dispatchSystemAudioChunk(chunk, geminiSessionRef),
+                onStatus: (level, message) => {
+                    if (level === 'error' || level === 'warning') {
+                        sendToRenderer('update-status', `Audio: ${message}`);
+                    }
+                },
+            });
+        } catch (error) {
+            console.error('Error starting Linux audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('stop-linux-audio', async event => {
+        try {
+            await linuxAudio.stopLinuxAudioCapture();
+            return { success: true };
+        } catch (error) {
+            console.error('Error stopping Linux audio capture:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('close-session', async event => {
         try {
             stopMacOSAudioCapture();
+            await linuxAudio.stopLinuxAudioCapture();
 
             if (currentProviderMode === 'cloud') {
                 closeCloud();
@@ -1358,6 +1395,7 @@ module.exports = {
     startMacOSAudioCapture,
     convertStereoToMono,
     stopMacOSAudioCapture,
+    stopLinuxAudioCapture: linuxAudio.stopLinuxAudioCapture,
     sendAudioToGemini,
     sendImageToGeminiHttp,
     setupGeminiIpcHandlers,

--- a/src/utils/linuxAudio.js
+++ b/src/utils/linuxAudio.js
@@ -1,0 +1,605 @@
+const { spawn, execFile } = require('child_process');
+
+const SAMPLE_RATE = 24000;
+const BYTES_PER_SAMPLE = 2;
+const CHANNELS = 1;
+const CHUNK_DURATION = 0.1;
+const CHUNK_SIZE = SAMPLE_RATE * BYTES_PER_SAMPLE * CHANNELS * CHUNK_DURATION;
+
+const TAP_SINK_NAME = 'cd_tap';
+const PW_RECORD_PREFIX = 'pw-record:input_';
+
+const MAX_QUEUED_CHUNKS = 20;
+const START_WATCHDOG_TIMEOUT = 1500;
+const MAX_START_ATTEMPTS = 3;
+const MAX_RESPAWN_ATTEMPTS = 3;
+const RESPAWN_DELAY = 1000;
+const SINK_POLL_INTERVAL = 5000;
+const LINK_SETUP_TIMEOUT = 2000;
+const OVERFLOW_WARN_INTERVAL = 1000;
+
+let audioProc = null;
+let audioBuffer = Buffer.alloc(0);
+let receivedAnyData = false;
+let linksConfirmed = false;
+let capturedSink = null;
+let mode = 'tap';
+let stopped = true;
+
+let sendQueue = [];
+let sending = false;
+let lastOverflowWarn = 0;
+
+let startWatchdog = null;
+let sinkPollTimer = null;
+let respawnTimer = null;
+let startAttempts = 0;
+let respawnAttempts = 0;
+
+let isIntercepting = false;
+let originalDefaultSink = null;
+let loopbackSink = null;
+
+let onChunk = null;
+let onStatus = null;
+
+function execCommand(command, args, timeoutMs = 3000) {
+    return new Promise((resolve, reject) => {
+        execFile(command, args, { timeout: timeoutMs, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+            if (error) {
+                reject(new Error(`${command} ${args.join(' ')} failed: ${error.message}${stderr ? ` - ${stderr.trim()}` : ''}`));
+            } else {
+                resolve(stdout.trim());
+            }
+        });
+    });
+}
+
+function emitStatus(level, message) {
+    console.log(`[linux-audio:${level}] ${message}`);
+    if (typeof onStatus === 'function') {
+        onStatus(level, message);
+    }
+}
+
+async function getDefaultSink() {
+    return execCommand('pactl', ['get-default-sink']);
+}
+
+function findModuleIds(output, moduleName, argSubstring) {
+    const ids = [];
+    const re = /Module #(\d+)\n((?:[ \t].*\n?)*)/g;
+    let match;
+    while ((match = re.exec(output)) !== null) {
+        const block = match[2];
+        const nameMatch = block.match(/Name:\s*(\S+)/);
+        if (!nameMatch || nameMatch[1] !== moduleName) continue;
+        if (argSubstring && !block.includes(argSubstring)) continue;
+        ids.push(match[1]);
+    }
+    return ids;
+}
+
+async function unloadModulesForTapSink() {
+    try {
+        const modulesOutput = await execCommand('pactl', ['list', 'modules'], 3000);
+        const ids = [
+            ...findModuleIds(modulesOutput, 'module-null-sink', TAP_SINK_NAME),
+            ...findModuleIds(modulesOutput, 'module-loopback', `${TAP_SINK_NAME}.monitor`),
+        ];
+        for (const id of ids) {
+            try {
+                await execCommand('pactl', ['unload-module', id], 3000);
+                emitStatus('info', `Unloaded stale module #${id}`);
+            } catch (error) {
+                console.warn('Failed to unload stale module', id, error.message);
+            }
+        }
+    } catch (error) {
+        console.warn('Failed to inspect pulse modules:', error.message);
+    }
+}
+
+async function setupInterception() {
+    const realSink = await getDefaultSink();
+
+    await unloadModulesForTapSink();
+
+    const tapOutput = await execCommand('pactl', ['load-module', 'module-null-sink', `sink_name=${TAP_SINK_NAME}`], 3000);
+    const tapModuleId = Number.parseInt(tapOutput, 10);
+    if (!Number.isFinite(tapModuleId)) {
+        throw new Error('Failed to create virtual sink (no module id returned)');
+    }
+    emitStatus('info', `Virtual sink created (module #${tapModuleId})`);
+
+    // Mark early so a partial failure below still cleans up the tap sink.
+    isIntercepting = true;
+
+    try {
+        const loopbackOutput = await execCommand(
+            'pactl',
+            ['load-module', 'module-loopback', `source=${TAP_SINK_NAME}.monitor`, `sink=${realSink}`],
+            3000
+        );
+        const loopbackModuleId = Number.parseInt(loopbackOutput, 10);
+        if (!Number.isFinite(loopbackModuleId)) {
+            throw new Error('Failed to create loopback (no module id returned)');
+        }
+        loopbackSink = realSink;
+        emitStatus('info', `Loopback created (module #${loopbackModuleId})`);
+
+        const switched = await setDefaultSinkVerified(TAP_SINK_NAME);
+        if (switched) {
+            emitStatus('info', `Default sink temporarily switched to ${TAP_SINK_NAME}`);
+        } else {
+            emitStatus('warning', `Could not switch default sink to ${TAP_SINK_NAME} - interception may capture nothing`);
+        }
+    } catch (error) {
+        await restoreInterception();
+        throw error;
+    }
+}
+
+async function setDefaultSinkVerified(sinkName, retries = 5) {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        await execCommand('pactl', ['set-default-sink', sinkName], 3000);
+        const current = await getDefaultSink();
+        if (current === sinkName) return true;
+        if (attempt < retries) {
+            await new Promise(resolve => setTimeout(resolve, 300));
+        }
+    }
+    return false;
+}
+
+async function restoreInterception() {
+    if (!isIntercepting) return;
+    isIntercepting = false;
+
+    if (originalDefaultSink) {
+        try {
+            const currentDefault = await getDefaultSink();
+            if (currentDefault === TAP_SINK_NAME) {
+                const restored = await setDefaultSinkVerified(originalDefaultSink);
+                emitStatus(
+                    'info',
+                    restored ? `Default sink restored to ${originalDefaultSink}` : `Failed to restore default sink to ${originalDefaultSink}`
+                );
+            }
+        } catch (error) {
+            console.warn('Failed to restore default sink:', error.message);
+        }
+        originalDefaultSink = null;
+    }
+
+    try {
+        const modulesOutput = await execCommand('pactl', ['list', 'modules'], 3000);
+        const loopbackIds = findModuleIds(modulesOutput, 'module-loopback', `${TAP_SINK_NAME}.monitor`);
+        for (const id of loopbackIds) {
+            await execCommand('pactl', ['unload-module', id], 3000);
+        }
+        const tapIds = findModuleIds(modulesOutput, 'module-null-sink', TAP_SINK_NAME);
+        for (const id of tapIds) {
+            await execCommand('pactl', ['unload-module', id], 3000);
+        }
+        emitStatus('info', 'Virtual sink modules unloaded');
+    } catch (error) {
+        console.warn('Failed to unload tap sink modules:', error.message);
+    }
+
+    loopbackSink = null;
+}
+
+async function rePointLoopback(newSink) {
+    if (!isIntercepting || loopbackSink === newSink) return;
+    try {
+        const modulesOutput = await execCommand('pactl', ['list', 'modules'], 3000);
+        const loopbackIds = findModuleIds(modulesOutput, 'module-loopback', `${TAP_SINK_NAME}.monitor`);
+        for (const id of loopbackIds) {
+            await execCommand('pactl', ['unload-module', id], 3000);
+        }
+        await execCommand('pactl', ['load-module', 'module-loopback', `source=${TAP_SINK_NAME}.monitor`, `sink=${newSink}`], 3000);
+        loopbackSink = newSink;
+        emitStatus('info', `Loopback re-pointed to ${newSink}`);
+    } catch (error) {
+        emitStatus('warning', `Failed to re-point loopback: ${error.message}`);
+    }
+}
+
+function killProcess() {
+    const proc = audioProc;
+    audioProc = null;
+    if (proc && !proc.killed) {
+        proc.kill('SIGTERM');
+    }
+}
+
+function dispatchChunk(chunk) {
+    if (sendQueue.length >= MAX_QUEUED_CHUNKS) {
+        sendQueue.shift();
+        const now = Date.now();
+        if (now - lastOverflowWarn >= OVERFLOW_WARN_INTERVAL) {
+            lastOverflowWarn = now;
+            emitStatus('warning', 'Audio send queue overflow - dropping oldest chunk');
+        }
+    }
+    sendQueue.push(chunk);
+    drainQueue();
+}
+
+async function drainQueue() {
+    if (sending) return;
+    sending = true;
+    try {
+        while (sendQueue.length > 0) {
+            const chunk = sendQueue.shift();
+            try {
+                await onChunk(chunk);
+            } catch (error) {
+                console.error('Linux audio chunk consumer error:', error.message);
+            }
+        }
+    } finally {
+        sending = false;
+    }
+}
+
+function handleStdoutData(chunk) {
+    if (!receivedAnyData) {
+        receivedAnyData = true;
+        if (startWatchdog) {
+            clearTimeout(startWatchdog);
+            startWatchdog = null;
+        }
+        startAttempts = 0;
+        respawnAttempts = 0;
+        emitStatus('info', 'Audio data flowing');
+    }
+
+    audioBuffer = audioBuffer.length === 0 ? chunk : Buffer.concat([audioBuffer, chunk]);
+
+    while (audioBuffer.length >= CHUNK_SIZE) {
+        const piece = audioBuffer.subarray(0, CHUNK_SIZE);
+        audioBuffer = audioBuffer.subarray(CHUNK_SIZE);
+        // Discard data captured before the monitor link is confirmed - it may
+        // come from the microphone fallback
+        if (linksConfirmed) {
+            dispatchChunk(piece);
+        }
+    }
+
+    const maxBuffered = CHUNK_SIZE * MAX_QUEUED_CHUNKS;
+    if (audioBuffer.length > maxBuffered) {
+        audioBuffer = audioBuffer.subarray(audioBuffer.length - maxBuffered);
+    }
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function findRecordInputPeers() {
+    const output = await execCommand('pw-link', ['-l'], 3000);
+    const peers = {};
+    const lines = output.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        const match = lines[i].match(new RegExp(`^${PW_RECORD_PREFIX}(FL|FR)$`));
+        if (match) {
+            for (let j = i + 1; j < lines.length && j < i + 4; j++) {
+                const peerMatch = lines[j].match(/\|<\-\s*(.+)/);
+                if (peerMatch) {
+                    peers[match[1]] = peerMatch[1].trim();
+                    break;
+                }
+            }
+        }
+    }
+    return peers;
+}
+
+async function ensureCaptureLinks(target) {
+    // Wait for the pw-record input ports to appear in the graph
+    let appeared = false;
+    const deadline = Date.now() + LINK_SETUP_TIMEOUT;
+    while (Date.now() < deadline) {
+        try {
+            const ports = await execCommand('pw-link', ['-i'], 2000);
+            if (ports.includes(`${PW_RECORD_PREFIX}FL`)) {
+                appeared = true;
+                break;
+            }
+        } catch (error) {
+            console.warn('Port listing failed:', error.message);
+        }
+        await sleep(100);
+    }
+    if (!appeared) return false;
+
+    // Disconnect any fallback links (pw-record falls back to the microphone
+    // when the target sink's monitor is idle)
+    try {
+        const peers = await findRecordInputPeers();
+        for (const channel of ['FL', 'FR']) {
+            if (peers[channel]) {
+                await execCommand('pw-link', ['-d', peers[channel], `${PW_RECORD_PREFIX}${channel}`], 2000);
+            }
+        }
+    } catch (error) {
+        console.warn('Failed to disconnect fallback links:', error.message);
+    }
+
+    // Force links from the target sink's monitor ports
+    for (const channel of ['FL', 'FR']) {
+        try {
+            await execCommand('pw-link', [`${target}:monitor_${channel}`, `${PW_RECORD_PREFIX}${channel}`], 2000);
+        } catch (error) {
+            console.warn(`Failed to link ${target}:monitor_${channel}:`, error.message);
+            return false;
+        }
+    }
+
+    // Verify with retries - link creation is asynchronous
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            const peers = await findRecordInputPeers();
+            if (peers.FL && peers.FL.startsWith(`${target}:monitor_`)) return true;
+        } catch (error) {
+            console.warn('Link verification failed:', error.message);
+        }
+        await sleep(100);
+    }
+    return false;
+}
+
+async function getSinkState(target) {
+    try {
+        const sinks = await execCommand('pactl', ['list', 'sinks', 'short'], 3000);
+        const line = sinks.split('\n').find(entry => entry.split('\t')[1] === target);
+        if (!line) return 'MISSING';
+        return line.includes('RUNNING') ? 'RUNNING' : 'IDLE';
+    } catch (error) {
+        return 'UNKNOWN';
+    }
+}
+
+function restartCapture(target, reason, proc) {
+    if (proc && proc !== audioProc) return;
+    emitStatus('warning', `${reason} - restarting capture`);
+    killProcess();
+    if (startAttempts < MAX_START_ATTEMPTS) {
+        startAttempts++;
+        spawnCapture(target);
+    } else {
+        emitStatus('error', `Audio capture failed: ${reason}`);
+        stopLinuxAudioCapture();
+    }
+}
+
+async function postSpawnLinkSetup(target, proc) {
+    const linked = await ensureCaptureLinks(target);
+    if (stopped || proc !== audioProc) return;
+    if (!linked) {
+        restartCapture(target, 'Unable to link capture to the output monitor', proc);
+        return;
+    }
+    linksConfirmed = true;
+    emitStatus('info', 'Capture linked to output monitor');
+    armDataWatchdog(target);
+}
+
+function armDataWatchdog(target) {
+    if (startWatchdog) {
+        clearTimeout(startWatchdog);
+    }
+    const proc = audioProc;
+    startWatchdog = setTimeout(async () => {
+        startWatchdog = null;
+        if (stopped || proc !== audioProc) return;
+        if (receivedAnyData) return;
+
+        const sinkState = await getSinkState(target);
+        if (sinkState === 'MISSING') {
+            restartCapture(target, 'Capture target sink disappeared', proc);
+            return;
+        }
+        if (sinkState === 'IDLE') {
+            // Healthy but silent - keep waiting for audio to start
+            armDataWatchdog(target);
+            return;
+        }
+        // Sink is running but no data is flowing - capture is broken
+        restartCapture(target, 'No audio data while sink is running', proc);
+    }, START_WATCHDOG_TIMEOUT);
+}
+
+function handleUnexpectedClose(code) {
+    if (stopped) return;
+    audioProc = null;
+    if (respawnAttempts >= MAX_RESPAWN_ATTEMPTS) {
+        emitStatus('error', `Audio capture stopped unexpectedly (exit code ${code})`);
+        stopLinuxAudioCapture();
+        return;
+    }
+    respawnAttempts++;
+    emitStatus('warning', `Audio capture exited (code ${code}) - respawning (${respawnAttempts}/${MAX_RESPAWN_ATTEMPTS})`);
+    respawnTimer = setTimeout(async () => {
+        respawnTimer = null;
+        if (stopped) return;
+        try {
+            let target = capturedSink;
+            if (isIntercepting) {
+                target = TAP_SINK_NAME;
+                const modulesOutput = await execCommand('pactl', ['list', 'modules'], 3000);
+                if (findModuleIds(modulesOutput, 'module-null-sink', TAP_SINK_NAME).length === 0) {
+                    await setupInterception();
+                }
+            }
+            spawnCapture(target);
+        } catch (error) {
+            emitStatus('error', `Failed to restart audio capture: ${error.message}`);
+            stopLinuxAudioCapture();
+        }
+    }, RESPAWN_DELAY);
+}
+
+function spawnCapture(target) {
+    capturedSink = target;
+    audioBuffer = Buffer.alloc(0);
+    receivedAnyData = false;
+    linksConfirmed = false;
+
+    const proc = spawn(
+        'pw-record',
+        ['--target', target, '--format', 's16', '--rate', String(SAMPLE_RATE), '--channels', String(CHANNELS), '--container', 'raw', '-'],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    audioProc = proc;
+
+    proc.stdout.on('data', chunk => {
+        if (proc !== audioProc) return;
+        handleStdoutData(chunk);
+    });
+
+    proc.stderr.on('data', data => {
+        const message = data.toString().trim();
+        if (message) console.error('[pw-record stderr]', message);
+    });
+
+    proc.on('error', error => {
+        if (proc !== audioProc) return;
+        if (stopped) return;
+        emitStatus('error', `Failed to start pw-record: ${error.message}. Install PipeWire (and pipewire-pulse for sink monitoring).`);
+        stopLinuxAudioCapture();
+    });
+
+    proc.on('close', code => {
+        if (proc !== audioProc) return;
+        handleUnexpectedClose(code);
+    });
+
+    postSpawnLinkSetup(target, proc);
+}
+
+function startSinkPolling() {
+    stopSinkPolling();
+    sinkPollTimer = setInterval(async () => {
+        if (stopped) return;
+        try {
+            const currentDefault = await getDefaultSink();
+            if (isIntercepting) {
+                if (currentDefault !== TAP_SINK_NAME && currentDefault !== loopbackSink) {
+                    await rePointLoopback(currentDefault);
+                }
+            } else if (currentDefault !== capturedSink) {
+                emitStatus('info', `Default sink changed to ${currentDefault} - restarting capture`);
+                killProcess();
+                spawnCapture(currentDefault);
+            }
+        } catch (error) {
+            console.warn('Sink polling failed:', error.message);
+        }
+    }, SINK_POLL_INTERVAL);
+}
+
+function stopSinkPolling() {
+    if (sinkPollTimer) {
+        clearInterval(sinkPollTimer);
+        sinkPollTimer = null;
+    }
+}
+
+async function recoverStaleInterception() {
+    try {
+        const modulesOutput = await execCommand('pactl', ['list', 'modules'], 3000);
+        const staleIds = [
+            ...findModuleIds(modulesOutput, 'module-loopback', `${TAP_SINK_NAME}.monitor`),
+            ...findModuleIds(modulesOutput, 'module-null-sink', TAP_SINK_NAME),
+        ];
+        if (staleIds.length === 0) return;
+        console.log('Found stale interception modules from a previous session - cleaning up');
+        for (const id of staleIds) {
+            try {
+                await execCommand('pactl', ['unload-module', id], 3000);
+            } catch (error) {
+                console.warn('Failed to unload stale module', id, error.message);
+            }
+        }
+    } catch (error) {
+        console.warn('Stale interception cleanup failed:', error.message);
+    }
+}
+
+async function startLinuxAudioCapture(options) {
+    const { mode: requestedMode = 'tap', onChunk: chunkCallback, onStatus: statusCallback } = options || {};
+
+    if (typeof chunkCallback !== 'function') {
+        throw new Error('onChunk callback is required');
+    }
+
+    if (stopped === false) {
+        await stopLinuxAudioCapture();
+    }
+
+    mode = requestedMode === 'intercept' ? 'intercept' : 'tap';
+    onChunk = chunkCallback;
+    onStatus = statusCallback;
+    stopped = false;
+    startAttempts = 0;
+    respawnAttempts = 0;
+    sendQueue = [];
+    sending = false;
+
+    try {
+        if (mode === 'intercept') {
+            originalDefaultSink = await getDefaultSink();
+            await setupInterception();
+            spawnCapture(TAP_SINK_NAME);
+        } else {
+            const defaultSink = await getDefaultSink();
+            spawnCapture(defaultSink);
+        }
+
+        startSinkPolling();
+        emitStatus('info', `Capture started (${mode} mode)`);
+        return { success: true, mode, target: capturedSink };
+    } catch (error) {
+        stopped = true;
+        await restoreInterception().catch(() => {});
+        throw error;
+    }
+}
+
+async function stopLinuxAudioCapture() {
+    if (stopped) return;
+    stopped = true;
+
+    if (startWatchdog) {
+        clearTimeout(startWatchdog);
+        startWatchdog = null;
+    }
+    if (respawnTimer) {
+        clearTimeout(respawnTimer);
+        respawnTimer = null;
+    }
+    stopSinkPolling();
+
+    killProcess();
+    audioBuffer = Buffer.alloc(0);
+    linksConfirmed = false;
+    sendQueue = [];
+    sending = false;
+
+    if (isIntercepting) {
+        await restoreInterception();
+    }
+
+    capturedSink = null;
+    emitStatus('info', 'Capture stopped');
+}
+
+module.exports = {
+    startLinuxAudioCapture,
+    stopLinuxAudioCapture,
+    recoverStaleInterception,
+    getDefaultSink,
+};

--- a/src/utils/linuxAudio.js
+++ b/src/utils/linuxAudio.js
@@ -102,6 +102,9 @@ async function unloadModulesForTapSink() {
 
 async function setupInterception() {
     const realSink = await getDefaultSink();
+    // Record before switching so restoreInterception can always put the
+    // user's sink back, regardless of which call site started interception.
+    originalDefaultSink = realSink;
 
     await unloadModulesForTapSink();
 

--- a/src/utils/linuxAudio.js
+++ b/src/utils/linuxAudio.js
@@ -488,7 +488,15 @@ function startSinkPolling() {
             const currentDefault = await getDefaultSink();
             if (isIntercepting) {
                 if (currentDefault !== TAP_SINK_NAME && currentDefault !== loopbackSink) {
+                    // The user picked a new output while intercepting - remember
+                    // it as the real sink to restore and re-assert the tap so
+                    // capture keeps working.
+                    originalDefaultSink = currentDefault;
                     await rePointLoopback(currentDefault);
+                    const switched = await setDefaultSinkVerified(TAP_SINK_NAME);
+                    if (!switched) {
+                        emitStatus('warning', 'Could not re-assert tap sink after output change');
+                    }
                 }
             } else if (currentDefault !== capturedSink) {
                 emitStatus('info', `Default sink changed to ${currentDefault} - restarting capture`);

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -346,6 +346,16 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
         console.log('Manual mode enabled - screenshots will be captured on demand only');
     } catch (err) {
         console.error('Error starting capture:', err);
+        // If system audio capture already started, stop it so we don't keep
+        // recording - and in intercept mode holding the default sink on the
+        // virtual tap - with no UI running.
+        if (isLinux) {
+            try {
+                await ipcRenderer.invoke('stop-linux-audio');
+            } catch (cleanupError) {
+                console.warn('Failed to stop Linux audio after capture error:', cleanupError);
+            }
+        }
         cheatingDaddy.setStatus('error');
     }
 }

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -249,41 +249,23 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
                 }
             }
         } else if (isLinux) {
-            // Linux - use display media for screen capture and try to get system audio
-            try {
-                // First try to get system audio via getDisplayMedia (works on newer browsers)
-                mediaStream = await navigator.mediaDevices.getDisplayMedia({
-                    video: {
-                        frameRate: 1,
-                        width: { ideal: 1920 },
-                        height: { ideal: 1080 },
-                    },
-                    audio: {
-                        sampleRate: SAMPLE_RATE,
-                        channelCount: 1,
-                        echoCancellation: false, // Don't cancel system audio
-                        noiseSuppression: false,
-                        autoGainControl: false,
-                    },
-                });
-
-                console.log('Linux system audio capture via getDisplayMedia succeeded');
-
-                // Setup audio processing for Linux system audio
-                setupLinuxSystemAudioProcessing();
-            } catch (systemAudioError) {
-                console.warn('System audio via getDisplayMedia failed, trying screen-only capture:', systemAudioError);
-
-                // Fallback to screen-only capture
-                mediaStream = await navigator.mediaDevices.getDisplayMedia({
-                    video: {
-                        frameRate: 1,
-                        width: { ideal: 1920 },
-                        height: { ideal: 1080 },
-                    },
-                    audio: false,
-                });
+            // Linux: system audio is captured in the main process via PipeWire
+            // (pw-record on the default sink monitor). getDisplayMedia audio is
+            // unreliable on Linux, so the screen capture is video-only here.
+            const captureMode = preferencesCache.linuxCaptureMode === 'intercept' ? 'intercept' : 'tap';
+            const audioResult = await ipcRenderer.invoke('start-linux-audio', { mode: captureMode });
+            if (!audioResult.success) {
+                console.warn('Failed to start Linux system audio capture:', audioResult.error);
             }
+
+            mediaStream = await navigator.mediaDevices.getDisplayMedia({
+                video: {
+                    frameRate: 1,
+                    width: { ideal: 1920 },
+                    height: { ideal: 1080 },
+                },
+                audio: false,
+            });
 
             // Additionally get microphone input for Linux based on audio mode
             if (audioMode === 'mic_only' || audioMode === 'both') {
@@ -310,7 +292,7 @@ async function startCapture(screenshotIntervalSeconds = 5, imageQuality = 'mediu
                 }
             }
 
-            console.log('Linux capture started - system audio:', mediaStream.getAudioTracks().length > 0, 'microphone mode:', audioMode);
+            console.log('Linux capture started - system audio:', audioResult.success, 'microphone mode:', audioMode);
         } else {
             // Windows - use display media with loopback for system audio
             mediaStream = await navigator.mediaDevices.getDisplayMedia({
@@ -399,36 +381,6 @@ function setupLinuxMicProcessing(micStream) {
 
     // Store processor reference for cleanup
     micAudioProcessor = micProcessor;
-}
-
-function setupLinuxSystemAudioProcessing() {
-    // Setup system audio processing for Linux (from getDisplayMedia)
-    audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
-    const source = audioContext.createMediaStreamSource(mediaStream);
-    audioProcessor = audioContext.createScriptProcessor(BUFFER_SIZE, 1, 1);
-
-    let audioBuffer = [];
-    const samplesPerChunk = SAMPLE_RATE * AUDIO_CHUNK_DURATION;
-
-    audioProcessor.onaudioprocess = async e => {
-        const inputData = e.inputBuffer.getChannelData(0);
-        audioBuffer.push(...inputData);
-
-        // Process audio in chunks
-        while (audioBuffer.length >= samplesPerChunk) {
-            const chunk = audioBuffer.splice(0, samplesPerChunk);
-            const pcmData16 = convertFloat32ToInt16(chunk);
-            const base64Data = arrayBufferToBase64(pcmData16.buffer);
-
-            await ipcRenderer.invoke('send-audio-content', {
-                data: base64Data,
-                mimeType: 'audio/pcm;rate=24000',
-            });
-        }
-    };
-
-    source.connect(audioProcessor);
-    audioProcessor.connect(audioContext.destination);
 }
 
 function setupWindowsLoopbackProcessing() {
@@ -695,6 +647,13 @@ function stopCapture() {
     if (isMacOS) {
         ipcRenderer.invoke('stop-macos-audio').catch(err => {
             console.error('Error stopping macOS audio:', err);
+        });
+    }
+
+    // Stop Linux audio capture if running (main-process PipeWire capture)
+    if (isLinux) {
+        ipcRenderer.invoke('stop-linux-audio').catch(err => {
+            console.error('Error stopping Linux audio:', err);
         });
     }
 

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -36,7 +36,14 @@ function createWindow(sendToRenderer, geminiSessionRef) {
     session.defaultSession.setDisplayMediaRequestHandler(
         (request, callback) => {
             desktopCapturer.getSources({ types: ['screen'] }).then(sources => {
-                callback({ video: sources[0], audio: 'loopback' });
+                // 'loopback' system audio is only supported on Windows (and macOS 14+,
+                // where this app uses SystemAudioDump instead). Requesting it elsewhere
+                // makes the whole capture fail or yields a dead audio track.
+                if (process.platform === 'win32' && request.audioRequested) {
+                    callback({ video: sources[0], audio: 'loopback' });
+                } else {
+                    callback({ video: sources[0] });
+                }
             });
         },
         { useSystemPicker: true }


### PR DESCRIPTION
## Summary

Adds working **system audio capture on Linux** so Live sessions receive what is playing on the machine (same behavior as macOS today).

On Linux `getDisplayMedia` loopback audio is unavailable and `SystemAudioDump` is macOS-only, so Linux users currently get no system audio at all. This PR captures it in the **main process** via PipeWire and feeds it into the existing Gemini audio path.

## How it works

- New module `src/utils/linuxAudio.js`: spawns `pw-record --target <default-sink> --format s16 --rate 24000 --channels 1` and streams mono PCM chunks over IPC.
- **Forced port links** via `pw-link` to the sink monitor: without this, `pw-record` silently falls back to the microphone when the monitor is idle and never re-links. Chunks captured before links are confirmed are discarded (they may be mic data).
- **Resilience**: start/running watchdogs, respawn with backoff, send queue with drop-oldest (max 20 chunks) so a slow session never blocks capture, 5s polling of the default sink — tap re-attaches automatically if the user switches outputs.
- **Interception mode** (optional, EasyEffects-style): creates a virtual sink `cd_tap`, points a loopback to the real output and switches the default sink, capturing everything played by any app. Modules live in the PipeWire server, so they survive app crashes; stale modules from previous runs are detected and cleaned up on startup (`recoverStaleInterception()`).
- IPC: `start-linux-audio` / `stop-linux-audio`; `close-session` stops capture as well.
- `dispatchSystemAudioChunk()` extracted and shared by both the macOS and Linux paths.
- `setDisplayMediaRequestHandler` is now platform-aware (`audio: 'loopback'` only on Windows).
- Local AI option hidden on Linux (not functional there yet).
- EPIPE guard on `process.stdout/stderr` in the main entry to prevent crashes when child processes close pipes.
- `extraResource` (SystemAudioDump) is now bundled for darwin builds only.

## Verification

Tested on Arch Linux / KDE Wayland / PipeWire 1.6.8:

- [x] Tone test: 440 Hz played through speakers → captured RMS/peak match source
- [x] Voice test: real speech clip played through speakers → captured waveform matches source
- [x] Silent start: links attach to the sink monitor, not the microphone
- [x] Intercept mode full cycle: default sink switch → capture → restore → modules unloaded
- [x] Stale interception recovery after a killed app instance
- [x] End-to-end Live API check: captured audio transcribed by Gemini Live, answer produced
- [x] `npm start` runs clean

## Notes

- Capture mode defaults to passive `tap`; `intercept` can be selected via config for setups where monitor taps are unreliable.
- No changes to macOS/Windows behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux system-audio capture with direct and interception modes.
  - Improved audio routing across supported providers.
  - Windows supports system audio during display capture; other platforms use video-only capture when audio is not requested.

- **Bug Fixes**
  - Improved recovery from Linux audio capture failures and stale sessions.
  - Prevented crashes when output streams close unexpectedly.
  - Linux automatically falls back from Local AI to BYOK.
  - Improved reliability during application shutdown and audio cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->